### PR TITLE
feat: add sth_globalPlayerDeathBlips convar to control death blip visibility

### DIFF
--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -242,7 +242,7 @@ namespace SurviveTheHuntClient
             // Check and report player death to the server if needed.
             if(!Game.Player.IsAlive && !PlayerState.DeathReported)
             {
-                TriggerServerEvent("sth:playerDied", new { PlayerId = Game.Player.ServerId, PlayerPosX = PlayerPos.X, PlayerPosY = PlayerPos.Y, PlayerPosZ = PlayerPos.Z });
+                TriggerServerEvent("sth:playerDied", new { PlayerId = Game.Player.ServerId, PlayerPosX = PlayerPos.X, PlayerPosY = PlayerPos.Y, PlayerPosZ = PlayerPos.Z, PlayerTeam = PlayerState.Team });
                 PlayerState.DeathReported = true;
             }
 
@@ -397,9 +397,12 @@ namespace SurviveTheHuntClient
                 }
             };
 
-            EventHandlers["sth:markPlayerDeath"] += new Action<float, float, float>((deathPosX, deathPosY, deathPosZ) =>
+            EventHandlers["sth:markPlayerDeath"] += new Action<float, float, float, Teams.Team>((deathPosX, deathPosY, deathPosZ, team) =>
             {
-                DeathBlips.Add(deathPosX, deathPosY, deathPosZ);
+                if (team == PlayerState.Team || string.Equals(GetConvar("sth_globalPlayerDeathBlips", "false"), "true", StringComparison.OrdinalIgnoreCase))
+                {
+                    DeathBlips.Add(deathPosX, deathPosY, deathPosZ);
+                }
             });
         }
     }

--- a/src/SurviveTheHuntServer/MainScript.cs
+++ b/src/SurviveTheHuntServer/MainScript.cs
@@ -156,7 +156,7 @@ namespace SurviveTheHuntServer
                         }
 
                         // Mark the player's death location with a blip for everyone.
-                        TriggerClientEvent("sth:markPlayerDeath", data.PlayerPosX, data.PlayerPosY, data.PlayerPosZ);
+                        TriggerClientEvent("sth:markPlayerDeath", data.PlayerPosX, data.PlayerPosY, data.PlayerPosZ, data.PlayerTeam);
                     })
                 },
                 {


### PR DESCRIPTION
This PR adds a `sth_globalPlayerDeathBlips` convar that can be used to display player death blips to all players regardless of their team. By default, this convar will assume `false` and therefore will only display player death blips to players from the same team.