### PR TITLE
fix: fixed hunted player mugshots not displaying

### DIFF
--- a/src/SurviveTheHuntClient/Constants.cs
+++ b/src/SurviveTheHuntClient/Constants.cs
@@ -41,9 +41,9 @@ namespace SurviveTheHuntClient
         public static readonly float OutOfBoundsYLimit = 1130f;
 
         /// <summary>
-        /// How often should the player mugshot textures be regenerated.
+        /// How long before a ping should the mugshot be generated?
         /// </summary>
-        public static readonly TimeSpan MugshotGenerationInterval = TimeSpan.FromSeconds(30);
+        public static readonly TimeSpan MugshotGenerationTimeout = TimeSpan.FromSeconds(10);
 
         /// <summary>
         /// Amount of time (in seconds) a player's death blip stays on the map.

--- a/src/SurviveTheHuntClient/GameState.cs
+++ b/src/SurviveTheHuntClient/GameState.cs
@@ -60,6 +60,11 @@ namespace SurviveTheHuntClient
             public DateTime LastHuntedMugshotGeneration { get; set; } = Utility.CurrentTime;
 
             /// <summary>
+            /// Expected time for the next ping.
+            /// </summary>
+            public DateTime NextMugshotTime { get; set; } = Utility.CurrentTime;
+
+            /// <summary>
             /// Time when hunt is meant to end & state be reset.
             /// This includes the delay for displaying the win/loss text.
             /// </summary>
@@ -111,15 +116,20 @@ namespace SurviveTheHuntClient
                 }
 
                 // If the mugshot texture requires regeneration, unregister it.
-                if(HuntedPlayerMugshot != null && Utility.CurrentTime - LastHuntedMugshotGeneration >= Constants.MugshotGenerationInterval)
+                if(HuntedPlayerMugshot != null && Utility.CurrentTime >= NextMugshotTime - Constants.MugshotGenerationTimeout)
                 {
                     UnregisterPedheadshot(HuntedPlayerMugshot.Id);
                     HuntedPlayerMugshot = null;
+
+                    // "Predict" the next mugshot time for now (the actual time will be sent down from the server in an event, but it's a fixed interval)
+                    // This is just to prevent the mugshot being re-registered on every tick (that would be bad...)
+                    NextMugshotTime = NextMugshotTime + (NextMugshotTime - LastHuntedMugshotGeneration);
                 }
 
                 // If the mugshot texture has been unregistered, generate a new one.
                 if (HuntedPlayerMugshot == null)
                 {
+                    Debug.WriteLine("Generating a mugshot!");
                     HuntedPlayerMugshot = new Texture() { Id = RegisterPedheadshot(HuntedPlayer.Character.Handle) };
                     LastHuntedMugshotGeneration = Utility.CurrentTime;
                 }

--- a/src/SurviveTheHuntClient/GameState.cs
+++ b/src/SurviveTheHuntClient/GameState.cs
@@ -120,7 +120,7 @@ namespace SurviveTheHuntClient
                 // If the mugshot texture has been unregistered, generate a new one.
                 if (HuntedPlayerMugshot == null)
                 {
-                    HuntedPlayerMugshot = new Texture() { Id = RegisterPedheadshotTransparent(HuntedPlayer.Character.Handle) };
+                    HuntedPlayerMugshot = new Texture() { Id = RegisterPedheadshot(HuntedPlayer.Character.Handle) };
                     LastHuntedMugshotGeneration = Utility.CurrentTime;
                 }
 

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -376,6 +376,9 @@ namespace SurviveTheHuntClient
                 {
                     "huntStartedByServer", new Action<dynamic>(data =>
                     {
+                        float secondsTillPing = data.NextNotification;
+                        GameState.Hunt.NextMugshotTime = Utility.CurrentTime + TimeSpan.FromSeconds(secondsTillPing);
+
                         string endTimeStr = data.EndTime;
                         DateTime endTime = DateTime.ParseExact(endTimeStr, "F", CultureInfo.InvariantCulture);
                         GameState.Hunt.InitialEndTime = endTime;
@@ -399,6 +402,8 @@ namespace SurviveTheHuntClient
                     "notifyAboutHuntedZone", new Action<dynamic>(data =>
                     {
                         string playerName = data.PlayerName;
+                        float nextNotificationTimeout = data.NextNotification;
+                        GameState.Hunt.NextMugshotTime = Utility.CurrentTime + TimeSpan.FromSeconds(nextNotificationTimeout);
                         HuntUI.NotifyAboutHuntedZone(Players[playerName], data.Position, ref GameState);
                     })
                 },

--- a/src/SurviveTheHuntServer/MainScript.cs
+++ b/src/SurviveTheHuntServer/MainScript.cs
@@ -178,14 +178,14 @@ namespace SurviveTheHuntServer
 
                         GameState.Hunt.Begin(randomPlayer);
 
-                        TriggerClientEvent("sth:huntStartedByServer", new { EndTime = GameState.Hunt.EndTime.ToString("F", CultureInfo.InvariantCulture) });
+                        TriggerClientEvent("sth:huntStartedByServer", new { EndTime = GameState.Hunt.EndTime.ToString("F", CultureInfo.InvariantCulture), NextNotification = (float)Constants.HuntedPingInterval.TotalSeconds });
                     })
                 },
                 {
                     "broadcastHuntedZone", new Action<dynamic>(data =>
                     {
                         Vector3 pos = data.Position;
-                        TriggerClientEvent("sth:notifyAboutHuntedZone", new { PlayerName = GameState.Hunt.HuntedPlayer.Name, Position = pos });
+                        TriggerClientEvent("sth:notifyAboutHuntedZone", new { PlayerName = GameState.Hunt.HuntedPlayer.Name, Position = pos, NextNotification = (float)Constants.HuntedPingInterval.TotalSeconds });
                     })
                 }
             };


### PR DESCRIPTION
This PR replaces `RegisterPedheadshotTransparent()` with `RegisterPedheadshot()` which does not have the render target limitation that caused the mugshot texture to be missing, and has negligible impact on visuals.

The mugshot is also now generated within a 10s window prior to the hunted player's radius being pinged on the map, as opposed to regenerating every 30 seconds. This ensures the player's appearance is as up to date as possible while also allowing enough time for the ped headshot job to complete.

Closes #40