### PR TITLE
fix: fixed vehicles not being cleaned up properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Fixes
+- Fixed previous batch of vehicles not being deleted when using `/spawncars`. ([#44](https://github.com/tomezpl/sth-gamemode/issues/44))
+
+## Known issues
+- Due to how the fix for [#44](https://github.com/tomezpl/sth-gamemode/issues/44) is implemented, there is an additional 3.5s delay when using `/spawncars`.
+  - This is in order to allow the server to properly delete the existing vehicles.
+  - A fix to mitigate this will be introduced in a future version.
+
 # 1.1.0
 ## Features
 - Added player death markers on the radar. Use `setr sth_deathbliplifespan <seconds>` to override the number of seconds the marker stays on the map. Use `setr sth_globalPlayerDeathBlips true` to make hunter death blips visible to hunted players. ([#26](https://github.com/tomezpl/sth-gamemode/issues/26))  ([#32](https://github.com/tomezpl/sth-gamemode/issues/32)) 

--- a/src/SurviveTheHuntClient/Helpers/SyncedVehicle.cs
+++ b/src/SurviveTheHuntClient/Helpers/SyncedVehicle.cs
@@ -1,0 +1,43 @@
+﻿using CitizenFX.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SurviveTheHuntClient.Helpers
+{
+    public class SyncedVehicle
+    {
+        private readonly Func<Entity> _vehicleGetter;
+
+        public Vehicle Vehicle { get => (Vehicle)(_vehicleGetter()); }
+
+        private SyncedVehicle(int? entityHandle = null, int? netId = null)
+        {
+            if(entityHandle == null && netId == null)
+            {
+                throw new ArgumentNullException("Either entityHandle or netId needs to be a non-null value.");
+            }
+
+            if(entityHandle.HasValue)
+            {
+                _vehicleGetter = () => Vehicle.FromHandle(entityHandle.Value);
+            }
+            else if(netId.HasValue)
+            {
+                _vehicleGetter = () => Vehicle.FromNetworkId(netId.Value);
+            }
+        }
+
+        public static SyncedVehicle FromNetId(int netId)
+        {
+            return new SyncedVehicle(netId: netId);
+        }
+
+        public static SyncedVehicle FromHandle(int entityHandle)
+        {
+            return new SyncedVehicle(entityHandle: entityHandle);
+        }
+    }
+}

--- a/src/SurviveTheHuntClient/Helpers/SyncedVehicle.cs
+++ b/src/SurviveTheHuntClient/Helpers/SyncedVehicle.cs
@@ -16,6 +16,9 @@ namespace SurviveTheHuntClient.Helpers
 
         public Vehicle Vehicle { get => (Vehicle)(_vehicleGetter()); }
 
+        public int? NetId;
+        public int? Handle;
+
         private SyncedVehicle(int? entityHandle = null, int? netId = null)
         {
             if(entityHandle == null && netId == null)
@@ -31,6 +34,9 @@ namespace SurviveTheHuntClient.Helpers
             {
                 _vehicleGetter = () => Vehicle.FromNetworkId(netId.Value);
             }
+
+            Handle = entityHandle;
+            NetId = netId;
         }
 
         public static SyncedVehicle FromNetId(int netId)

--- a/src/SurviveTheHuntClient/Helpers/SyncedVehicle.cs
+++ b/src/SurviveTheHuntClient/Helpers/SyncedVehicle.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 
 namespace SurviveTheHuntClient.Helpers
 {
+    /// <summary>
+    /// Helper class to simplify using the Vehicle natives. Allows vehicles to be looked up either via handle or netID.
+    /// </summary>
     public class SyncedVehicle
     {
         private readonly Func<Entity> _vehicleGetter;

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -218,13 +218,14 @@ namespace SurviveTheHuntClient
 
                 SetEntityAsMissionEntity(spawnedVehicle.Handle, true, true);
 
+                SetVehicleModKit(spawnedVehicle.Handle, 0);
+
                 // Set all vehicle mods to maximum.
                 for (int i = 0; i < 50; i++)
                 {
                     int nbMods = GetNumVehicleMods(spawnedVehicle.Handle, i);
                     if(nbMods > 0)
                     {
-                        SetVehicleModKit(spawnedVehicle.Handle, i);
                         SetVehicleMod(spawnedVehicle.Handle, i, nbMods - 1, false);
                     }
                 }

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -35,7 +35,6 @@ namespace SurviveTheHuntClient
         /// <summary>
         /// Vehicles spawned by the gamemode at the spawn area. This is used to delete vehicles on the next <see cref="SpawnCars"/> call.
         /// </summary>
-        /// <remarks>TODO: Move this to server-side so any player can spawn vehicles with the previous batch deleting properly?</remarks>
         protected List<SyncedVehicle> SpawnedVehicles = new List<SyncedVehicle>();
 
         /// <summary>
@@ -132,11 +131,13 @@ namespace SurviveTheHuntClient
                     TriggerServerEvent("sth:startHunt");
                 }), false);
 
-                RegisterCommand("spawncars", new Action(() =>
+                RegisterCommand("spawncars", new Action(async () =>
                 {
                     if (!IsSpawningCars)
                     {
                         IsSpawningCars = true;
+                        await SpawnCars();
+                        IsSpawningCars = false;
                     }
                 }), false);
 
@@ -303,12 +304,6 @@ namespace SurviveTheHuntClient
             {
                 TriggerServerEvent("sth:playerDied", new { PlayerId = Game.Player.ServerId, PlayerPosX = PlayerPos.X, PlayerPosY = PlayerPos.Y, PlayerPosZ = PlayerPos.Z, PlayerTeam = PlayerState.Team });
                 PlayerState.DeathReported = true;
-            }
-
-            if(IsSpawningCars)
-            {
-                await SpawnCars();
-                IsSpawningCars = false;
             }
 
             if (SpawnedVehiclesNeedSync)

--- a/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
+++ b/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Constants.cs" />
     <Compile Include="GameState.cs" />
     <Compile Include="Helpers\DeathBlips.cs" />
+    <Compile Include="Helpers\SyncedVehicle.cs" />
     <Compile Include="HuntUI.cs" />
     <Compile Include="MainScript.cs" />
     <Compile Include="PlayerState.cs" />

--- a/src/SurviveTheHuntServer/Events.cs
+++ b/src/SurviveTheHuntServer/Events.cs
@@ -1,10 +1,14 @@
 ﻿using CitizenFX.Core;
 using SurviveTheHuntServer.Utils;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace SurviveTheHuntServer
 {
     public partial class MainScript
     {
+        private readonly List<int> SpawnedVehicles = new List<int>();
+
         public void OnServerResourceStart(string resourceName)
         {
             Debug.WriteLine($"{resourceName} resource started!");
@@ -13,12 +17,65 @@ namespace SurviveTheHuntServer
             {
                 // Reload the config file every time the resource is started.
                 BroadcastConfig(Config.Init());
+                SyncVehicles(SpawnedVehicles);
             }
         }
 
         public void ClientStarted([FromSource] Player player)
         {
             BroadcastConfig(player, Config);
+            SyncVehicles(SpawnedVehicles);
+        }
+
+        [EventHandler("sth:reqSyncVehicles")]
+        public void SyncVehiclesRequested([FromSource] Player player, string vehicleNetIdsPacked)
+        {
+            Debug.WriteLine($"Received vehicleNetIdsPacked: {vehicleNetIdsPacked}");
+            int validNetIdCount = 0;
+            int[] vehicleNetIds = vehicleNetIdsPacked.Split(';').Select((netIdStr) => {
+                Debug.WriteLine(netIdStr);
+                if (int.TryParse(netIdStr, out int netId))
+                {
+                    Debug.WriteLine($"{netId}");
+                    validNetIdCount++;
+                    return netId;
+                }
+                else
+                {
+                    return -1;
+                }
+            }).ToArray();
+
+            if(validNetIdCount > 0)
+            {
+                Debug.WriteLine($"Overwriting SpawnedVehicles with {vehicleNetIds.Length} netIds");
+                SpawnedVehicles.Clear();
+                SpawnedVehicles.AddRange(vehicleNetIds);
+
+                SyncVehicles(vehicleNetIdsPacked);
+            }
+        }
+
+        private void SyncVehicles(List<int> vehicleNetIds)
+        {
+            string vehicleNetIdsPacked = "";
+            foreach (int netId in vehicleNetIds)
+            {
+                vehicleNetIdsPacked += $"{netId};";
+            }
+
+            if(vehicleNetIdsPacked.Length > 1)
+            {
+                // Remove trailing semicolon.
+                vehicleNetIdsPacked = vehicleNetIdsPacked.Remove(vehicleNetIdsPacked.Length - 1, 1);
+
+                SyncVehicles(vehicleNetIdsPacked);
+            }
+        }
+
+        private void SyncVehicles(string vehicleNetIdsPacked)
+        {
+            TriggerClientEvent("sth:recvSyncVehicles", vehicleNetIdsPacked);
         }
     }
 }

--- a/src/SurviveTheHuntServer/Events.cs
+++ b/src/SurviveTheHuntServer/Events.cs
@@ -1,7 +1,9 @@
 ﻿using CitizenFX.Core;
 using SurviveTheHuntServer.Utils;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using static CitizenFX.Core.Native.API;
 
 namespace SurviveTheHuntServer
 {
@@ -76,6 +78,20 @@ namespace SurviveTheHuntServer
         private void SyncVehicles(string vehicleNetIdsPacked)
         {
             TriggerClientEvent("sth:recvSyncVehicles", vehicleNetIdsPacked);
+        }
+
+        [EventHandler("sth:reqDeleteVehicle")]
+        public void DeleteVehicle([FromSource] Player player, int vehicleNetId)
+        {
+            Debug.WriteLine($"Player {player.Name} ({player.Handle}) is requesting to delete vehicle with net ID {vehicleNetId}");
+            try
+            {
+                TriggerClientEvent("sth:recvDeleteVehicle", vehicleNetId);
+            }
+            catch(Exception ex)
+            {
+                Debug.WriteLine($"Couldn't delete vehicle: {ex.ToString()}");
+            }
         }
     }
 }

--- a/src/SurviveTheHuntServer/MainScript.cs
+++ b/src/SurviveTheHuntServer/MainScript.cs
@@ -66,6 +66,7 @@ namespace SurviveTheHuntServer
 
                 Config = new Config();
                 BroadcastConfig(Config);
+                SyncVehicles(SpawnedVehicles);
             }
         }
 

--- a/src/SurviveTheHuntServer/MainScript.cs
+++ b/src/SurviveTheHuntServer/MainScript.cs
@@ -73,6 +73,16 @@ namespace SurviveTheHuntServer
         protected void PlayerDisconnected([FromSource] Player player, string reason)
         {
             HuntedPlayerQueue.RemovePlayer(player);
+
+            // FiveM docs don't seem to clearly communicate as to whether the player list is updated when this event fires,
+            // so let's check if there are 0 players (or 1 player and it's the one who just left).
+            int playerCount = GetNumPlayerIndices();
+            if (playerCount == 0 || (playerCount == 1 && Players[GetPlayerFromIndex(0)] == player))
+            {
+                // Clear the spawned cars list as they will be gone for good once all players have left.
+                Debug.WriteLine("All players have left, clearing vehicles!");
+                SpawnedVehicles.Clear();
+            }
         }
 
         protected void PlayerJoining([FromSource] Player player, string oldId)


### PR DESCRIPTION
This PR fixes a bug where spawning vehicles would not clean up the previously spawned set, causing them to spawn on top of each other.

Closes #44 