### PR TITLE
Configurable max health

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ Below are all commands made available by this script:
 * `/respawn`
   * Respawns the local player at the starting point.
 
+### Convars
+[Convars](https://docs.fivem.net/docs/scripting-reference/convars/) are FiveM's way of configuring variables that can be used by the resource (in this case, the gamemode itself).
+
+You can provide your own values for these convars in your `server.cfg` file.
+
+Survive the Hunt exposes the following convars:
+
+| Convar | Description | Default value |
+| --- | --- | --- |
+| `sth_maxHealth` | The amount of health the player spawns with | 228 |
+| `sth_globalPlayerDeathBlips` | Should player death blips be visible to players from the enemy team? | false | 
+| `sth_deathbliplifespan` | The number of seconds a player's death blip is visible for on the map. | 5 |
+
+These are supposed to be server-replicated, so you'll want to use the `setr` command, like so: `setr sth_globalPlayerDeathBlips false`, `setr sth_deathbliplifespan 5` etc.
+
 ### Setup
 #### Building
 **You don't have to build binaries from source. I provide pre-compiled binaries as a release. Skip to the "Installation" section if that's what you're here for.**

--- a/src/SurviveTheHuntClient/Constants.cs
+++ b/src/SurviveTheHuntClient/Constants.cs
@@ -13,12 +13,12 @@ namespace SurviveTheHuntClient
         /// <summary>
         /// How long the hunted player's radius stays at max. opacity on the radar (in seconds).
         /// </summary>
-        public static readonly float HuntedBlipLifespan = 50f;
+        public const float HuntedBlipLifespan = 50f;
 
         /// <summary>
         /// How long it takes for the hunted player's radius to fade from max opacity to 0 (in seconds).
         /// </summary>
-        public static readonly float HuntedBlipFadeoutTime = 5f;
+        public const float HuntedBlipFadeoutTime = 5f;
 
         /// <summary>
         /// How long each feed post message stays on the screen (in seconds) assuming the duration multiplier of 1.
@@ -26,7 +26,7 @@ namespace SurviveTheHuntClient
         /// <remarks>
         /// This was manually measured in gameplay.
         /// </remarks>
-        public static readonly float FeedPostMessageDuration = 15f;
+        public const float FeedPostMessageDuration = 15f;
 
         /// <summary>
         /// Weapon loadouts for each team.

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -59,6 +59,11 @@ namespace SurviveTheHuntClient
         /// Blips used to represent player deaths on the radar.
         /// </summary>
         private readonly DeathBlips DeathBlips;
+        
+        /// <summary>
+        /// The local player's ped handle as of the previous tick. Used to track ped changes so max health can be applied correctly.
+        /// </summary>
+        private int PreviousTickPedHandle = 0;
 
         public MainScript()
         {
@@ -277,6 +282,20 @@ namespace SurviveTheHuntClient
                 Debug.WriteLine($"GameState: Hunt.IsInProgress: {GameState.Hunt.IsInProgress}, Hunt.IsEnding: {GameState.Hunt.IsEnding}");
                 HuntUI.DisplayObjective(ref GameState, ref PlayerState, GameState.Hunt.IsEnding);
             }
+
+            // Set the player's max health.
+            ApplyMaxHealth(true);
+        }
+
+        /// <summary>
+        /// Applies max health to the current player ped and optionally replenishes their health.
+        /// </summary>
+        /// <param name="restore">Should the player ped's health be replenished to max?</param>
+        protected void ApplyMaxHealth(bool restore = false)
+        {
+            int maxHealth = GetConvarInt("sth_maxHealth", SharedConstants.DefaultMaxHealth);
+            SetPedMaxHealth(PlayerPedId(), maxHealth);
+            SetEntityHealth(PlayerPedId(), maxHealth);
         }
 
         protected async Task UpdateLoop()
@@ -285,6 +304,8 @@ namespace SurviveTheHuntClient
             {
                 ResetPlayerStamina(PlayerId());
                 PlayerPos = Game.PlayerPed.Position;
+
+                Debug.WriteLine($"{GetEntityHealth(PlayerPedId())}");
             }
 
             GameState.Hunt.UpdateHuntedMugshot();
@@ -330,6 +351,16 @@ namespace SurviveTheHuntClient
             FixCarsInSpawn();
 
             DeathBlips.ClearExpiredBlips();
+
+            if(Game.PlayerPed?.Exists() == true)
+            {
+                if(PreviousTickPedHandle != Game.PlayerPed.Handle)
+                {
+                    ApplyMaxHealth();
+                }
+
+                PreviousTickPedHandle = Game.PlayerPed.Handle;
+            }
 
             Wait(0);
         }

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -308,8 +308,6 @@ namespace SurviveTheHuntClient
             {
                 ResetPlayerStamina(PlayerId());
                 PlayerPos = Game.PlayerPed.Position;
-
-                Debug.WriteLine($"{GetEntityHealth(PlayerPedId())}");
             }
 
             GameState.Hunt.UpdateHuntedMugshot();
@@ -360,6 +358,7 @@ namespace SurviveTheHuntClient
             {
                 if(PreviousTickPedHandle != Game.PlayerPed.Handle)
                 {
+                    Debug.WriteLine("Ped changed, setting max health");
                     ApplyMaxHealth();
                 }
 

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -295,7 +295,11 @@ namespace SurviveTheHuntClient
         {
             int maxHealth = GetConvarInt("sth_maxHealth", SharedConstants.DefaultMaxHealth);
             SetPedMaxHealth(PlayerPedId(), maxHealth);
-            SetEntityHealth(PlayerPedId(), maxHealth);
+            
+            if (restore)
+            {
+                SetEntityHealth(PlayerPedId(), maxHealth);
+            }
         }
 
         protected async Task UpdateLoop()

--- a/src/SurviveTheHuntShared/Constants.cs
+++ b/src/SurviveTheHuntShared/Constants.cs
@@ -199,5 +199,12 @@ namespace SurviveTheHuntShared
             new Coord() { Position = new Vector3(822.22f, -3143.73f, 5.9f), Heading = 0f }, // 25
             new Coord() { Position = new Vector3(818.22f, -3143.73f, 5.9f), Heading = 0f }  // 26
         };
+
+        /// <summary>
+        /// Default max health to set for a player ped.
+        /// 
+        /// Taken from https://gtaforums.com/topic/681401-weapons-information-by-game-files/
+        /// </summary>
+        public const ushort DefaultMaxHealth = 228;
     }
 }


### PR DESCRIPTION
This PR adds the ability to configure max player health via a convar `sth_maxHealth`.

By default it sets the convar to a value of `228`. This should match GTAO's values, but it may need tweaking for a balanced experience.

A convar table has also been added to the README.

Closes #51