### PR TITLE
Prep phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Features
 - Added support for joining matches in progress. ([#15](https://github.com/tomezpl/sth-gamemode/issues/15))
 - Added the `sth_maxHealth` convar to allow tweaking players' max health. ([#51](https://github.com/tomezpl/sth-gamemode/issues/51))
+- Added a safe zone at the Terminal spawn.  ([#52](https://github.com/tomezpl/sth-gamemode/issues/52))
+- Added a prep phase during which the hunted player is invincible and hunters can't leave the spawn.  ([#52](https://github.com/tomezpl/sth-gamemode/issues/52))
+  - The prep phase duration can be set with the `sth_prepPhaseDuration` convar. 
 
 ## Fixes
 - Fixed matches not ending if the hunted player has disconnected.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Survive the Hunt exposes the following convars:
 | `sth_maxHealth` | The amount of health the player spawns with | 228 |
 | `sth_globalPlayerDeathBlips` | Should player death blips be visible to players from the enemy team? | false | 
 | `sth_deathbliplifespan` | The number of seconds a player's death blip is visible for on the map. | 5 |
+| `sth_prepPhaseDuration` | The number of seconds dedicated to a prep phase before the hunt. This is added to the total round time. | 60 |
 
 These are supposed to be server-replicated, so you'll want to use the `setr` command, like so: `setr sth_globalPlayerDeathBlips false`, `setr sth_deathbliplifespan 5` etc.
 

--- a/src/SurviveTheHuntClient/GameState.cs
+++ b/src/SurviveTheHuntClient/GameState.cs
@@ -92,6 +92,14 @@ namespace SurviveTheHuntClient
             /// </remarks>
             public DateTime PrepPhaseEndTime { get; set; } = new DateTime();
 
+            private bool _wasHuntInProgressLastFrame = false;
+
+            /// <summary>
+            /// Was <see cref="IsStarted"/> true last frame?
+            /// This can be used for checking if the hunt has only just started.
+            /// </summary>
+            public bool WasHuntInProgressLastFrame { get => _wasHuntInProgressLastFrame; }
+
             /// <summary>
             /// Ends the hunt and resets the state so that it can be started again.
             /// </summary>
@@ -120,6 +128,14 @@ namespace SurviveTheHuntClient
                 // Reset the player's weapons.
                 Ped playerPed = Game.PlayerPed;
                 playerState.TakeAwayWeapons(ref playerPed);
+            }
+
+            /// <summary>
+            /// Logic tick - needs to be called on every script update!
+            /// </summary>
+            public void Tick()
+            {
+                _wasHuntInProgressLastFrame = IsStarted;
             }
 
             /// <summary>

--- a/src/SurviveTheHuntClient/GameState.cs
+++ b/src/SurviveTheHuntClient/GameState.cs
@@ -47,6 +47,11 @@ namespace SurviveTheHuntClient
             public bool CanBeStarted { get { return !IsInProgress && !IsEnding; } }
 
             /// <summary>
+            /// Is the prep phase still active?
+            /// </summary>
+            public bool IsPrepPhase { get { return Utility.CurrentTime < PrepPhaseEndTime; } }
+
+            /// <summary>
             /// Currently hunted player.
             /// </summary>
             public Player HuntedPlayer { get; set; } = null;
@@ -76,6 +81,16 @@ namespace SurviveTheHuntClient
             /// Expected end time (set at start of the hunt).
             /// </summary>
             public DateTime InitialEndTime { get; set; } = new DateTime();
+
+            /// <summary>
+            /// Time when the prep phase is already over.
+            /// </summary>
+            /// <remarks>
+            /// Note: this does not always refer to the actual hunt start time. For a player joining in progress,
+            /// this value will be equal to <see cref="Utility.CurrentTime"/>, as we only need to know
+            /// how much longer the prep phase is going to last.
+            /// </remarks>
+            public DateTime PrepPhaseEndTime { get; set; } = new DateTime();
 
             /// <summary>
             /// Ends the hunt and resets the state so that it can be started again.
@@ -161,15 +176,17 @@ namespace SurviveTheHuntClient
     public partial class MainScript
     {
         [EventHandler(SurviveTheHuntShared.Events.Client.ReceiveGameState)]
-        public void ReceiveGameState(bool isStarted, int huntedPlayerServerId, long startTimeTicks, long endTimeTicks, long lastPingTimeTicks)
+        public void ReceiveGameState(bool isStarted, int huntedPlayerServerId, long startTimeTicks, long endTimeTicks, long lastPingTimeTicks, long prepPhaseEndTicks)
         {
             Debug.WriteLine("Received game state");
             if (huntedPlayerServerId != int.MinValue && NetworkIsPlayerConnected(GetPlayerFromServerId(huntedPlayerServerId)))
             {
                 Player huntedPlayer = new Player(GetPlayerFromServerId(huntedPlayerServerId));
                 Debug.WriteLine($"Game state: isStarted={isStarted}, huntedPlayer={huntedPlayer.Name}, startTime={new DateTime(startTimeTicks)}, endTime={new DateTime(endTimeTicks)}, lastPingTime={new DateTime(lastPingTimeTicks)}");
+                
+                // TODO: shouldn't this use Utility.CurrentTime instead of DateTime.UtcNow?
                 float secondsTillPing = (float)((new DateTime(lastPingTimeTicks, DateTimeKind.Utc) + SharedConstants.HuntedPingInterval) - DateTime.UtcNow).TotalSeconds;
-                HuntStartedByServer(secondsTillPing, new DateTime(endTimeTicks, DateTimeKind.Utc));
+                HuntStartedByServer(secondsTillPing, new DateTime(endTimeTicks, DateTimeKind.Utc), new DateTime(prepPhaseEndTicks, DateTimeKind.Utc) - Utility.CurrentTime);
                 NotifyTeam(huntedPlayer == Player.Local ? Teams.Team.Hunted : Teams.Team.Hunters, huntedPlayer);
             }
         }

--- a/src/SurviveTheHuntClient/HuntUI.cs
+++ b/src/SurviveTheHuntClient/HuntUI.cs
@@ -175,6 +175,8 @@ namespace SurviveTheHuntClient
                 return;
             }
 
+            string header = "TIME LEFT";
+
             // Format the time string.
             string timeStr = "";
             try
@@ -185,7 +187,17 @@ namespace SurviveTheHuntClient
                 }
                 else
                 {
-                    TimeSpan remainingTime = gameState.Hunt.InitialEndTime - Utility.CurrentTime;
+                    TimeSpan remainingTime;
+                    if (!gameState.Hunt.IsPrepPhase)
+                    {
+                        remainingTime = gameState.Hunt.InitialEndTime - Utility.CurrentTime;
+                    }
+                    else
+                    {
+                        remainingTime = gameState.Hunt.PrepPhaseEndTime - Utility.CurrentTime;
+                        header = "PREP PHASE";
+                    }
+
                     timeStr = $"{remainingTime.Minutes.ToString("00", CultureInfo.InvariantCulture)}:{remainingTime.Seconds.ToString("00", CultureInfo.InvariantCulture)}";
                 }
             }
@@ -197,7 +209,7 @@ namespace SurviveTheHuntClient
             // Get rect width to fit the text.
             SetTextScale(0f, 0.55f);
             BeginTextCommandWidth("STRING");
-            AddTextComponentString("TIME LEFT  00:00");
+            AddTextComponentString($"{header}  00:00");
             float timebarWidth = EndTextCommandGetWidth(true);
 
             // Load and draw the timerbar using the rect width we've measured.
@@ -213,7 +225,7 @@ namespace SurviveTheHuntClient
             EndTextCommandDisplayText(0.94f, 0.835f);
             SetTextScale(0, 0.35f);
             BeginTextCommandDisplayText("STRING");
-            AddTextComponentString("TIME LEFT");
+            AddTextComponentString(header);
             EndTextCommandDisplayText(0.94f - timebarWidth / 2.35f, 0.845f);
             SetTextScale(0, 1f);
         }

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -178,7 +178,7 @@ namespace SurviveTheHuntClient
                 // Notify the server this client has started so the config can be sent down. This is needed for resource restarts etc.
                 TriggerServerEvent(Events.Server.ClientStarted);
 
-                SafeZoneRadiusBlipHandle = AddBlipForRadius(SharedConstants.DockSpawn.X, SharedConstants.DockSpawn.Y, SharedConstants.DefaultSpawnSafeZoneRadius, SharedConstants.DefaultSpawnSafeZoneRadius);
+                SafeZoneRadiusBlipHandle = AddBlipForRadius(SharedConstants.DockSpawn.X, SharedConstants.DockSpawn.Y, SharedConstants.DockSpawn.Z, SharedConstants.DefaultSpawnSafeZoneRadius);
                 SetBlipColour(SafeZoneRadiusBlipHandle, 69);
                 SetBlipAlpha(SafeZoneRadiusBlipHandle, 128);
                 SetBlipDisplay(SafeZoneRadiusBlipHandle, 6);

--- a/src/SurviveTheHuntClient/PlayerState.cs
+++ b/src/SurviveTheHuntClient/PlayerState.cs
@@ -37,6 +37,11 @@ namespace SurviveTheHuntClient
         public Teams.Team Team { get; set; } = Teams.Team.Hunters;
 
         /// <summary>
+        /// Is the player currently waiting to be teleported to spawn because of the hunt starting?
+        /// </summary>
+        public bool WaitingToTeleportToSpawn { get; set; } = false;
+
+        /// <summary>
         /// Manages the state of the bigmap widget on the HUD.
         /// </summary>
         public class BigmapState

--- a/src/SurviveTheHuntServer/GameState.cs
+++ b/src/SurviveTheHuntServer/GameState.cs
@@ -41,7 +41,7 @@ namespace SurviveTheHuntServer
             /// <summary>
             /// UTC time when the hunt session should end (it could end before that).
             /// </summary>
-            public DateTime EndTime { get { return StartTime + SharedConstants.HuntDuration; } }
+            public DateTime EndTime { get { return StartTime + SharedConstants.HuntDuration + EndTimeOffset; } }
 
             /// <summary>
             /// UTC time of last time the hunted player was pinged on the map.
@@ -49,16 +49,28 @@ namespace SurviveTheHuntServer
             public DateTime LastPingTime { get; set; } = DateTime.UtcNow;
 
             /// <summary>
+            /// UTC time of when the prep phase is supposed to end and the actual hunt begins.
+            /// </summary>
+            public DateTime PrepPhaseEndTime { get; set; } = DateTime.UtcNow;
+
+            /// <summary>
+            /// Any extra time that needs to be added to the round duration (e.g. prep phase, or whatever modifiers affect the end time).
+            /// </summary>
+            public TimeSpan EndTimeOffset { get; set; } = TimeSpan.Zero;
+
+            /// <summary>
             /// Starts the hunt for a given player.
             /// </summary>
             /// <param name="huntedPlayer"></param>
-            public void Begin(Player huntedPlayer)
+            public void Begin(Player huntedPlayer, ulong prepPhaseSeconds = 0)
             {
                 IsStarted = true;
                 HuntedPlayer = huntedPlayer;
                 WinningTeam = Teams.Team.Hunted;
                 StartTime = DateTime.UtcNow;
-                LastPingTime = DateTime.UtcNow;
+                LastPingTime = DateTime.UtcNow + TimeSpan.FromSeconds(prepPhaseSeconds) - SharedConstants.HuntedPingInterval;
+                PrepPhaseEndTime = StartTime + TimeSpan.FromSeconds(prepPhaseSeconds);
+                EndTimeOffset = TimeSpan.FromSeconds(prepPhaseSeconds);
             }
 
             /// <summary>
@@ -83,7 +95,16 @@ namespace SurviveTheHuntServer
     {
         public void SendGameState(Player player, GameState gameState)
         {
-            TriggerClientEvent(player, SurviveTheHuntShared.Events.Client.ReceiveGameState, gameState.Hunt.IsStarted, gameState.Hunt.HuntedPlayer != null ? int.Parse(gameState.Hunt.HuntedPlayer.Handle) : int.MinValue, gameState.Hunt.StartTime.Ticks, gameState.Hunt.EndTime.Ticks, gameState.Hunt.LastPingTime.Ticks);
+            TriggerClientEvent
+            (
+                player, 
+                SurviveTheHuntShared.Events.Client.ReceiveGameState, 
+                gameState.Hunt.IsStarted, 
+                gameState.Hunt.HuntedPlayer != null ? int.Parse(gameState.Hunt.HuntedPlayer.Handle) : int.MinValue, 
+                gameState.Hunt.StartTime.Ticks, gameState.Hunt.EndTime.Ticks, 
+                gameState.Hunt.LastPingTime.Ticks, 
+                gameState.Hunt.PrepPhaseEndTime.Ticks
+            );
         }
     }
 }

--- a/src/SurviveTheHuntServer/MainScript.cs
+++ b/src/SurviveTheHuntServer/MainScript.cs
@@ -194,9 +194,16 @@ namespace SurviveTheHuntServer
                         TriggerClientEvent(randomPlayer, Events.Client.NotifyHuntedPlayer);
                         TriggerClientEvent(Events.Client.NotifyHunters, new { HuntedPlayerServerId = int.Parse(randomPlayer.Handle) });
 
-                        GameState.Hunt.Begin(randomPlayer);
+                        ulong prepPhaseSeconds = (ulong)GetConvarInt("sth_prepPhaseDuration", SharedConstants.DefaultPrepPhaseSeconds);
 
-                        TriggerClientEvent(Events.Client.HuntStartedByServer, new { EndTime = GameState.Hunt.EndTime.ToString("F", CultureInfo.InvariantCulture), NextNotification = (float)SharedConstants.HuntedPingInterval.TotalSeconds });
+                        GameState.Hunt.Begin(randomPlayer, prepPhaseSeconds);
+
+                        TriggerClientEvent(Events.Client.HuntStartedByServer, new 
+                        { 
+                            EndTime = GameState.Hunt.EndTime.ToString("F", CultureInfo.InvariantCulture), 
+                            NextNotification = (float)prepPhaseSeconds + (float)SharedConstants.HuntedPingInterval.TotalSeconds,
+                            PrepPhaseDuration = prepPhaseSeconds
+                        });
                     })
                 },
                 {

--- a/src/SurviveTheHuntShared/Constants.cs
+++ b/src/SurviveTheHuntShared/Constants.cs
@@ -206,5 +206,15 @@ namespace SurviveTheHuntShared
         /// Taken from https://gtaforums.com/topic/681401-weapons-information-by-game-files/
         /// </summary>
         public const ushort DefaultMaxHealth = 228;
+
+        /// <summary>
+        /// Default safe zone radius measured from spawn point - this will be used to prevent players from attacking each other before prep phase ends.
+        /// </summary>
+        public const float DefaultSpawnSafeZoneRadius = 40f;
+
+        /// <summary>
+        /// Default number of seconds to allow for the prep phase.
+        /// </summary>
+        public const ushort DefaultPrepPhaseSeconds = 60;
     }
 }


### PR DESCRIPTION
This PR adds a prep phase/safe zone feature: being in a radius of 40 units around the Terminal spawn makes the player invincible. The hunted player is invincible for the duration of the prep phase (configured via the `sth_prepPhaseDuration` convar; by default 60 seconds). Hunters are prevented from leaving the safe zone for the duration of the prep phase. Any player found outside the safe zone when the prep phase starts is teleported back to the spawn.

Closes #52