### PR TITLE
fix: fixed wanted level stats updating despite never wanted

### DIFF
--- a/src/SurviveTheHuntClient/Helpers/WantedLevelHelper.cs
+++ b/src/SurviveTheHuntClient/Helpers/WantedLevelHelper.cs
@@ -1,0 +1,13 @@
+﻿using static CitizenFX.Core.Native.API;
+
+
+namespace SurviveTheHuntClient.Helpers
+{
+    public static class WantedLevelHelper
+    {
+        public static void DisableWantedLevel()
+        {
+            SetMaxWantedLevel(0);
+        }
+    }
+}

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -399,6 +399,8 @@ namespace SurviveTheHuntClient
                 SetPedRandomProps(Player.Local.Character.Handle);
             }
 
+            WantedLevelHelper.DisableWantedLevel();
+
             LastSpawnTime = DateTime.UtcNow.Ticks;
         }
 
@@ -472,9 +474,6 @@ namespace SurviveTheHuntClient
 
             PlayerState.UpdateWeapons(Game.PlayerPed);
 
-            // Make sure the player can't get cops.
-            ClearPlayerWantedLevel(PlayerId());
-
             // Check and report player death to the server if needed.
             if(!Game.Player.IsAlive && !PlayerState.DeathReported)
             {
@@ -542,20 +541,26 @@ namespace SurviveTheHuntClient
 
             DeathBlips.ClearExpiredBlips();
 
-            if(Game.PlayerPed?.Exists() == true)
-            {
-                if(PreviousTickPedHandle != Game.PlayerPed.Handle)
-                {
-                    Debug.WriteLine("Ped changed, setting max health");
-                    ApplyMaxHealth();
-                }
-
-                PreviousTickPedHandle = Game.PlayerPed.Handle;
-            }
+            RunPedChangedChecks();
 
             TickLbgCharNeoIntegration();
 
             Wait(0);
+        }
+
+        private void RunPedChangedChecks()
+        {
+            if (Game.PlayerPed?.Exists() == true)
+            {
+                if (PreviousTickPedHandle != Game.PlayerPed.Handle)
+                {
+                    Debug.WriteLine("Ped changed, setting max health");
+                    ApplyMaxHealth();
+                    WantedLevelHelper.DisableWantedLevel();
+                }
+
+                PreviousTickPedHandle = Game.PlayerPed.Handle;
+            }
         }
 
         void ApplySafeZoneProtection(bool protectionActive, bool canLeaveSpawn, CfxVector3 safeZoneOrigin, float safeZoneRadius)
@@ -919,6 +924,8 @@ namespace SurviveTheHuntClient
                 Debug.WriteLine("Resetting health");
                 SetEntityHealth(playerPed, HealthState.Value);
             }
+
+            WantedLevelHelper.DisableWantedLevel();
         }
 
         [EventHandler(Events.Client.CharCreatorCreatorExited)]

--- a/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
+++ b/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
@@ -49,6 +49,7 @@
     <Compile Include="Helpers\DeathBlips.cs" />
     <Compile Include="Helpers\MinimapHelper.cs" />
     <Compile Include="Helpers\SyncedVehicle.cs" />
+    <Compile Include="Helpers\WantedLevelHelper.cs" />
     <Compile Include="HuntUI.cs" />
     <Compile Include="Integrations\LbgCharNeo.cs" />
     <Compile Include="MainScript.cs" />


### PR DESCRIPTION
This PR fixes the logic for disabling the wanted level. The wanted level is now capped at 0 instead of being cleared every frame.

Closes #68