### PR TITLE
feat: added team chat support

### DIFF
--- a/src/SurviveTheHuntServer/Extensions/TeamPlugins.cs
+++ b/src/SurviveTheHuntServer/Extensions/TeamPlugins.cs
@@ -11,25 +11,35 @@ namespace SurviveTheHuntServer
 {
     internal static class TeamPluginState
     {
+        /// <summary>
+        /// Lists of teams each player belongs to (key is player ID, value is list of teams they belong to).
+        /// 
+        /// Typically a player will only belong to one team but keeping it as a list might come in handy in the future.
+        /// </summary>
         public static Dictionary<int, List<Teams.Team>> PlayerTeams = new Dictionary<int, List<Teams.Team>>();
-        public static Dictionary<int, Action<Player, string>> PlayerCleanupActions = new Dictionary<int, Action<Player, string>>();
     }
 
     public partial class MainScript
     {
-        private void CleanupPlayerTeams([FromSource] Player player, string reason)
+        /// <summary>
+        /// Event handler that updates the <see cref="TeamPluginState"/> when a player leaves.
+        /// </summary>
+        /// <param name="player"></param>
+        /// <param name="reason"></param>
+        [EventHandler("playerDropped")]
+        public void CleanupPlayerTeams([FromSource] Player player, string reason)
         {
             if (int.TryParse(player.Handle, out int droppedPlayerId))
             {
+                // If the player belonged to any teams, run the "leave" plugin(s) for each of them (e.g. team chat) and remove the player's entry from the state.
                 if (TeamPluginState.PlayerTeams.TryGetValue(droppedPlayerId, out List<Teams.Team> playerTeams))
                 {
+                    Debug.WriteLine($"Removing {player.Name} from all {playerTeams.Count} team(s) they belonged to");
                     foreach (Teams.Team team in playerTeams)
                     {
                         LeaveTeam(player, team, false);
                     }
                     TeamPluginState.PlayerTeams.Remove(droppedPlayerId);
-                    EventHandlers["playerDropped"] -= TeamPluginState.PlayerCleanupActions[droppedPlayerId];
-                    TeamPluginState.PlayerCleanupActions.Remove(droppedPlayerId);
                 }
             }
         }
@@ -44,27 +54,15 @@ namespace SurviveTheHuntServer
             Debug.WriteLine($"Adding player {player.Name} to team {team}");
 
             TriggerEvent("chat-hook-teams:joinTeam", team, playerId);
-            bool createCleanupAction = true;
+
+            // Record the player's new team in the state.
             if(TeamPluginState.PlayerTeams.TryGetValue(playerId, out List<Teams.Team> playerTeams))
             {
                 playerTeams.Add(team);
-                createCleanupAction = false;
             }
             else
             {
                 TeamPluginState.PlayerTeams.Add(playerId, new List<Teams.Team>() { team });
-            }
-
-            if(createCleanupAction)
-            {
-                Action<Player, string> playerCleanupAction = new Action<Player, string>(CleanupPlayerTeams);
-
-                EventHandlers["playerDropped"] += playerCleanupAction;
-                TeamPluginState.PlayerCleanupActions.Add(playerId, playerCleanupAction);
-            }
-            else
-            {
-                Debug.WriteLine($"Player {player.Name} is already in a team, so no cleanup action is being created.");
             }
         }
 
@@ -78,6 +76,7 @@ namespace SurviveTheHuntServer
             TriggerEvent("chat-hook-teams:unjoinTeam", team, playerId);
             Debug.WriteLine($"Removed player {player.Name} from team {team}");
 
+            // Remove the player's team membership from the state.
             if (updateState && TeamPluginState.PlayerTeams.TryGetValue(playerId, out List<Teams.Team> playerTeams))
             {
                 playerTeams.RemoveAll(playerTeam => team == playerTeam);
@@ -88,12 +87,8 @@ namespace SurviveTheHuntServer
         {
             TriggerEvent("chat-hook-teams:resetTeams");
 
-            foreach(Action<Player, string> cleanupAction in TeamPluginState.PlayerCleanupActions.Values)
-            {
-                EventHandlers["playerDropped"] -= cleanupAction;
-            }
-
-            TeamPluginState.PlayerCleanupActions.Clear();
+            // Remove all players' teams.
+            TeamPluginState.PlayerTeams.Clear();
         }
     }
 }

--- a/src/SurviveTheHuntServer/Extensions/TeamPlugins.cs
+++ b/src/SurviveTheHuntServer/Extensions/TeamPlugins.cs
@@ -1,0 +1,99 @@
+﻿using CitizenFX.Core;
+using SurviveTheHuntShared.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static SurviveTheHuntShared.Core.Teams;
+
+namespace SurviveTheHuntServer
+{
+    internal static class TeamPluginState
+    {
+        public static Dictionary<int, List<Teams.Team>> PlayerTeams = new Dictionary<int, List<Teams.Team>>();
+        public static Dictionary<int, Action<Player, string>> PlayerCleanupActions = new Dictionary<int, Action<Player, string>>();
+    }
+
+    public partial class MainScript
+    {
+        private void CleanupPlayerTeams([FromSource] Player player, string reason)
+        {
+            if (int.TryParse(player.Handle, out int droppedPlayerId))
+            {
+                if (TeamPluginState.PlayerTeams.TryGetValue(droppedPlayerId, out List<Teams.Team> playerTeams))
+                {
+                    foreach (Teams.Team team in playerTeams)
+                    {
+                        LeaveTeam(player, team, false);
+                    }
+                    TeamPluginState.PlayerTeams.Remove(droppedPlayerId);
+                    EventHandlers["playerDropped"] -= TeamPluginState.PlayerCleanupActions[droppedPlayerId];
+                    TeamPluginState.PlayerCleanupActions.Remove(droppedPlayerId);
+                }
+            }
+        }
+
+        private void JoinTeam(Player player, Teams.Team team)
+        {
+            if(!int.TryParse(player.Handle, out int playerId))
+            {
+                return;
+            }
+
+            Debug.WriteLine($"Adding player {player.Name} to team {team}");
+
+            TriggerEvent("chat-hook-teams:joinTeam", team, playerId);
+            bool createCleanupAction = true;
+            if(TeamPluginState.PlayerTeams.TryGetValue(playerId, out List<Teams.Team> playerTeams))
+            {
+                playerTeams.Add(team);
+                createCleanupAction = false;
+            }
+            else
+            {
+                TeamPluginState.PlayerTeams.Add(playerId, new List<Teams.Team>() { team });
+            }
+
+            if(createCleanupAction)
+            {
+                Action<Player, string> playerCleanupAction = new Action<Player, string>(CleanupPlayerTeams);
+
+                EventHandlers["playerDropped"] += playerCleanupAction;
+                TeamPluginState.PlayerCleanupActions.Add(playerId, playerCleanupAction);
+            }
+            else
+            {
+                Debug.WriteLine($"Player {player.Name} is already in a team, so no cleanup action is being created.");
+            }
+        }
+
+        private void LeaveTeam(Player player, Teams.Team team, bool updateState = true)
+        {
+            if (!int.TryParse(player.Handle, out int playerId))
+            {
+                return;
+            }
+
+            TriggerEvent("chat-hook-teams:unjoinTeam", team, playerId);
+            Debug.WriteLine($"Removed player {player.Name} from team {team}");
+
+            if (updateState && TeamPluginState.PlayerTeams.TryGetValue(playerId, out List<Teams.Team> playerTeams))
+            {
+                playerTeams.RemoveAll(playerTeam => team == playerTeam);
+            }
+        }
+
+        private void ResetTeams()
+        {
+            TriggerEvent("chat-hook-teams:resetTeams");
+
+            foreach(Action<Player, string> cleanupAction in TeamPluginState.PlayerCleanupActions.Values)
+            {
+                EventHandlers["playerDropped"] -= cleanupAction;
+            }
+
+            TeamPluginState.PlayerCleanupActions.Clear();
+        }
+    }
+}

--- a/src/SurviveTheHuntServer/Extensions/TeamPlugins.cs
+++ b/src/SurviveTheHuntServer/Extensions/TeamPlugins.cs
@@ -2,10 +2,6 @@
 using SurviveTheHuntShared.Core;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using static SurviveTheHuntShared.Core.Teams;
 
 namespace SurviveTheHuntServer
 {
@@ -44,6 +40,11 @@ namespace SurviveTheHuntServer
             }
         }
 
+        /// <summary>
+        /// Notifies plugins to add a <paramref name="player"/> to a <paramref name="team"/>.
+        /// </summary>
+        /// <param name="player"></param>
+        /// <param name="team"></param>
         private void JoinTeam(Player player, Teams.Team team)
         {
             if(!int.TryParse(player.Handle, out int playerId))
@@ -66,6 +67,11 @@ namespace SurviveTheHuntServer
             }
         }
 
+        /// <summary>
+        /// Notifies plugins to remove a <paramref name="player"/> from a <paramref name="team"/>.
+        /// </summary>
+        /// <param name="player"></param>
+        /// <param name="team"></param>
         private void LeaveTeam(Player player, Teams.Team team, bool updateState = true)
         {
             if (!int.TryParse(player.Handle, out int playerId))
@@ -83,6 +89,9 @@ namespace SurviveTheHuntServer
             }
         }
 
+        /// <summary>
+        /// Notifies plugins to reset their team state(s).
+        /// </summary>
         private void ResetTeams()
         {
             TriggerEvent("chat-hook-teams:resetTeams");

--- a/src/SurviveTheHuntServer/GameState.cs
+++ b/src/SurviveTheHuntServer/GameState.cs
@@ -105,6 +105,11 @@ namespace SurviveTheHuntServer
                 gameState.Hunt.LastPingTime.Ticks, 
                 gameState.Hunt.PrepPhaseEndTime.Ticks
             );
+
+            if(gameState.Hunt.IsStarted)
+            {
+                JoinTeam(player, Teams.Team.Hunters);
+            }
         }
     }
 }

--- a/src/SurviveTheHuntServer/MainScript.cs
+++ b/src/SurviveTheHuntServer/MainScript.cs
@@ -213,14 +213,7 @@ namespace SurviveTheHuntServer
 
                         foreach(Player player in Players)
                         {
-                            if(player.Handle == randomPlayer.Handle)
-                            {
-                                JoinTeam(player, Teams.Team.Hunted);
-                            }
-                            else
-                            {
-                                JoinTeam(player, Teams.Team.Hunters);
-                            }
+                            JoinTeam(player, player.Handle == randomPlayer.Handle ? Teams.Team.Hunted : Teams.Team.Hunters);
                         }
                     })
                 },

--- a/src/SurviveTheHuntServer/MainScript.cs
+++ b/src/SurviveTheHuntServer/MainScript.cs
@@ -78,6 +78,7 @@ namespace SurviveTheHuntServer
             {
                 Debug.WriteLine("Hunted player left, ending hunt.");
                 GameState.Hunt.End(Teams.Team.Hunters);
+                ResetTeams();
                 NotifyWinner();
             }
 
@@ -120,6 +121,7 @@ namespace SurviveTheHuntServer
                 if (GameState.Hunt.EndTime <= DateTime.UtcNow)
                 {
                     GameState.Hunt.End(Teams.Team.Hunted);
+                    ResetTeams();
                     NotifyWinner();
                 }
 
@@ -179,6 +181,7 @@ namespace SurviveTheHuntServer
                         if(Hunt.CheckPlayerDeath(Players[playerId], ref GameState))
                         {
                             NotifyWinner();
+                            ResetTeams();
                         }
 
                         // Mark the player's death location with a blip for everyone.
@@ -207,6 +210,18 @@ namespace SurviveTheHuntServer
                             NextNotification = (float)prepPhaseSeconds + (float)SharedConstants.HuntedPingInterval.TotalSeconds,
                             PrepPhaseDuration = prepPhaseSeconds
                         });
+
+                        foreach(Player player in Players)
+                        {
+                            if(player.Handle == randomPlayer.Handle)
+                            {
+                                JoinTeam(player, Teams.Team.Hunted);
+                            }
+                            else
+                            {
+                                JoinTeam(player, Teams.Team.Hunters);
+                            }
+                        }
                     })
                 },
                 {

--- a/src/SurviveTheHuntServer/SurviveTheHuntServer.csproj
+++ b/src/SurviveTheHuntServer/SurviveTheHuntServer.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Events.cs" />
     <Compile Include="GameState.cs" />
     <Compile Include="Helpers\HuntedQueue.cs" />
+    <Compile Include="Extensions\TeamPlugins.cs" />
     <Compile Include="Hunt.cs" />
     <Compile Include="MainScript.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This PR adds logic and event dispatchers for [fivem-chat-hook-teams](https://github.com/tomezpl/fivem-chat-hook-teams) in order to allow hunters to use the stock text chat resource for communication without messages being exposed to the other team.