### PR TITLE
fix: fixed in-game clock not syncing for players joining in progress

### DIFF
--- a/src/SurviveTheHuntClient/Events.cs
+++ b/src/SurviveTheHuntClient/Events.cs
@@ -1,0 +1,20 @@
+﻿using CitizenFX.Core;
+using System;
+using Events = SurviveTheHuntShared.Events;
+using static CitizenFX.Core.Native.API;
+
+namespace SurviveTheHuntClient
+{
+    public partial class MainScript
+    {
+        [EventHandler(Events.Client.ReceiveClockSyncRequest)]
+        public void SendIngameClock()
+        {
+            int hours = GetClockHours();
+            int minutes = GetClockMinutes();
+            int seconds = GetClockSeconds();
+            Debug.WriteLine($"Server requested in-game clock resync, sending back {hours.ToString().PadLeft(2)}:{minutes.ToString().PadLeft(2)}:{seconds.ToString().PadLeft(2)}");
+            TriggerLatentServerEvent(Events.Server.ReceiveHuntedClock, sizeof(int) * 3, hours, minutes, seconds);
+        }
+    }
+}

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -369,6 +369,12 @@ namespace SurviveTheHuntClient
 
         protected void PlayerSpawnedCallback()
         {
+            if(!SpawnedOnce)
+            {
+                // If this is our first-spawn, try syncing the in-game clock just in case we're joining a hunt in progress.
+                TriggerLatentServerEvent(Events.Server.HuntedClockSyncRequested, 1);
+            }
+
             SpawnedOnce = true;
 
             // Refresh player's death state.

--- a/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
+++ b/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Constants.cs" />
+    <Compile Include="Events.cs" />
     <Compile Include="GameState.cs" />
     <Compile Include="Helpers\DeathBlips.cs" />
     <Compile Include="Helpers\MinimapHelper.cs" />

--- a/src/SurviveTheHuntServer/Events.cs
+++ b/src/SurviveTheHuntServer/Events.cs
@@ -104,5 +104,15 @@ namespace SurviveTheHuntServer
             Debug.WriteLine($"Sending {Events.Client.ReceiveHuntedClock} with {hours.ToString().PadLeft(2, '0')}:{minutes.ToString().PadLeft(2, '0')}:{seconds.ToString().PadLeft(2, '0')}");
             TriggerClientEvent(Events.Client.ReceiveHuntedClock, hours, minutes, seconds);
         }
+
+        [EventHandler(Events.Server.HuntedClockSyncRequested)]
+        public void RequestHuntedClockResync()
+        {
+            if (GameState.Hunt?.IsStarted == true && GameState.Hunt?.HuntedPlayer != null)
+            {
+                Debug.WriteLine($"Requesting in-game clock to be re-synced from the hunted player");
+                TriggerLatentClientEvent(GameState.Hunt.HuntedPlayer, Events.Client.ReceiveClockSyncRequest, 1);
+            }
+        }
     }
 }

--- a/src/SurviveTheHuntShared/Events.cs
+++ b/src/SurviveTheHuntShared/Events.cs
@@ -56,6 +56,11 @@ namespace SurviveTheHuntShared
             public const string CharCreatorForceExit = "lbg-char-neo:forceExit";
             public const string CharCreatorCreatorExited = "lbg-char-neo:creatorExited";
             public const string CharCreatorCreatorEntered = "lbg-char-neo:creatorEntered";
+
+            /// <summary>
+            /// The hunted player's client should receive this event before relaying the current in-game clock to a newly joined player via the server.
+            /// </summary>
+            public const string ReceiveClockSyncRequest = "sth:receiveHuntedClockSyncRequest";
         }
 
         /// <summary>
@@ -71,6 +76,12 @@ namespace SurviveTheHuntShared
             public const string ClientStarted = "sth:clientStarted";
             public const string RequestStartHunt = "sth:startHunt";
             public const string ReceiveHuntedClock = "sth:receiveClockFromHuntedPlayer";
+
+            /// <summary>
+            /// A newly joined client will trigger this server event, which will then send <see cref="Client.ReceiveClockSyncRequest"/> to the hunted player,
+            /// which in turn sends back the in-game clock value to the server, which will finally send it back to the newly joined client.
+            /// </summary>
+            public const string HuntedClockSyncRequested = "sth:huntedClockSyncRequested";
         }
     }
 }


### PR DESCRIPTION
This PR fixes an issue with in-game clock being out of sync for players who join a round in progress.

Every time a player spawns for the first time, a server event will be triggered to request the in-game clock from the hunted player and send it back to the server (which will relay it to all clients)

Closes #71 

![image](https://github.com/user-attachments/assets/156749d4-60c5-4869-868b-f47bc65e4227)
