### PR TITLE
Killfeed

### DIFF
--- a/src/SurviveTheHuntClient/Events.cs
+++ b/src/SurviveTheHuntClient/Events.cs
@@ -2,6 +2,7 @@
 using System;
 using Events = SurviveTheHuntShared.Events;
 using static CitizenFX.Core.Native.API;
+using SurviveTheHuntShared;
 
 namespace SurviveTheHuntClient
 {
@@ -15,6 +16,47 @@ namespace SurviveTheHuntClient
             int seconds = GetClockSeconds();
             Debug.WriteLine($"Server requested in-game clock resync, sending back {hours.ToString().PadLeft(2)}:{minutes.ToString().PadLeft(2)}:{seconds.ToString().PadLeft(2)}");
             TriggerLatentServerEvent(Events.Server.ReceiveHuntedClock, sizeof(int) * 3, hours, minutes, seconds);
+        }
+
+        [EventHandler(Events.Client.DisplayKill)]
+        public void DisplayNewKill(string payloadSerialized)
+        {
+            Debug.WriteLine(payloadSerialized);
+            KillFeedServerPayload payload = KillFeedServerPayload.Deserialize(payloadSerialized);
+            string label = payload.Label.WitnessGxt;
+
+            string localPlayerId = Player.Local.ServerId.ToString();
+            bool isAttacker = false;
+            if (payload.KillInfo.VictimServerId == localPlayerId)
+            {
+                label = payload.Label.VictimGxt;
+            }
+            else if(payload.KillInfo.AttackerServerId == localPlayerId)
+            {
+                label = payload.Label.AttackerGxt;
+                isAttacker = true;
+            }
+
+
+            string labelText = GetLabelText(label);
+            Debug.WriteLine($"Chosen label key: {label}, text: {labelText}");
+            Debug.WriteLine($"AttackerServerId = {payload.KillInfo.AttackerServerId}, VictimServerId = {payload.KillInfo.VictimServerId}");
+            BeginTextCommandThefeedPost(label);
+
+            int numTokens = KillFeedLabel.CountPlayerNames(labelText);
+            Debug.WriteLine($"label has {numTokens} tokens");
+            if(numTokens != 0)
+            {
+                AddTextComponentSubstringPlayerName(GetPlayerName(GetPlayerFromServerId(int.Parse(isAttacker ? payload.KillInfo.VictimServerId : payload.KillInfo.AttackerServerId))));
+                Debug.WriteLine($"Added {(isAttacker ? "victim" : "attacker")} server ID");
+            }
+            if(numTokens == 2)
+            {
+                AddTextComponentSubstringPlayerName(GetPlayerName(GetPlayerFromServerId(int.Parse(isAttacker ? payload.KillInfo.AttackerServerId : payload.KillInfo.VictimServerId))));
+                Debug.WriteLine($"Added {(!isAttacker ? "victim" : "attacker")} server ID");
+            }
+
+            EndTextCommandThefeedPostMpticker(true, true);
         }
     }
 }

--- a/src/SurviveTheHuntClient/Events.cs
+++ b/src/SurviveTheHuntClient/Events.cs
@@ -45,15 +45,26 @@ namespace SurviveTheHuntClient
 
             int numTokens = KillFeedLabel.CountPlayerNames(labelText);
             Debug.WriteLine($"label has {numTokens} tokens");
+            bool error = false;
             if(numTokens != 0)
             {
-                AddTextComponentSubstringPlayerName(GetPlayerName(GetPlayerFromServerId(int.Parse(isAttacker ? payload.KillInfo.VictimServerId : payload.KillInfo.AttackerServerId))));
-                Debug.WriteLine($"Added {(isAttacker ? "victim" : "attacker")} server ID");
+                if (int.TryParse(isAttacker || string.IsNullOrEmpty(payload.KillInfo.AttackerServerId) ? payload.KillInfo.VictimServerId : payload.KillInfo.AttackerServerId, out int firstPlayerId))
+                {
+                    AddTextComponentSubstringPlayerName(GetPlayerName(GetPlayerFromServerId(firstPlayerId)));
+                    Debug.WriteLine($"Added {(isAttacker ? "victim" : "attacker")} server ID");
+                }
+                else
+                {
+                    error = true;
+                }
             }
-            if(numTokens == 2)
+            if(numTokens == 2 && !error)
             {
-                AddTextComponentSubstringPlayerName(GetPlayerName(GetPlayerFromServerId(int.Parse(isAttacker ? payload.KillInfo.AttackerServerId : payload.KillInfo.VictimServerId))));
-                Debug.WriteLine($"Added {(!isAttacker ? "victim" : "attacker")} server ID");
+                if (int.TryParse(isAttacker ? payload.KillInfo.AttackerServerId : payload.KillInfo.VictimServerId, out int secondPlayerId))
+                {
+                    AddTextComponentSubstringPlayerName(GetPlayerName(GetPlayerFromServerId(secondPlayerId)));
+                    Debug.WriteLine($"Added {(!isAttacker ? "victim" : "attacker")} server ID");
+                }
             }
 
             EndTextCommandThefeedPostMpticker(true, true);

--- a/src/SurviveTheHuntClient/Helpers/KillTracker.cs
+++ b/src/SurviveTheHuntClient/Helpers/KillTracker.cs
@@ -1,0 +1,84 @@
+﻿using CitizenFX.Core;
+using CitizenFX.Core.Native;
+using SurviveTheHuntShared;
+using static CitizenFX.Core.Native.API;
+
+namespace SurviveTheHuntClient.Helpers
+{
+    internal static class KillTracker
+    {
+        public const float AttackerTimeout = 5f;
+
+        internal static float TimeSinceLastDamage = 0f;
+
+        internal static int? LastAttacker = null;
+
+        internal static int LastTickHealth = 0;
+
+        internal static void Reset()
+        {
+            LastAttacker = null;
+            LastTickHealth = 0;
+            TimeSinceLastDamage = 0f;
+        }
+
+        internal static void Tick()
+        {
+            int playerPed = PlayerPedId();
+
+            if(DoesEntityExist(playerPed))
+            {
+                int currentHealth = GetEntityHealth(playerPed);
+
+                int currentAttacker = 0;
+                if (currentHealth == 0)
+                {
+                    currentAttacker = GetPedSourceOfDeath(playerPed);
+                }
+
+                // If there was an attacker ped, set the controlling player as the latest attacker.
+                if(currentAttacker != 0)
+                {
+                    LastAttacker = NetworkGetPlayerIndexFromPed(currentAttacker);
+                    Debug.WriteLine($"Attacker: {GetPlayerName(LastAttacker.Value)}");
+                }
+                else if(TimeSinceLastDamage >= AttackerTimeout || currentHealth < LastTickHealth)
+                {
+                    LastAttacker = null;
+                }
+
+                if(currentHealth < LastTickHealth)
+                {
+                    TimeSinceLastDamage = 0f;
+                }
+                else
+                {
+                    if (TimeSinceLastDamage < AttackerTimeout)
+                    {
+                        TimeSinceLastDamage += GetFrameTime();
+                    }
+                }
+
+                LastTickHealth = currentHealth;
+            }
+        }
+
+        internal static KillFeedClientPayload GetKillInfo()
+        {
+            if(TimeSinceLastDamage < AttackerTimeout && LastAttacker.HasValue)
+            {
+                return new KillFeedClientPayload
+                {
+                    AttackerServerId = GetPlayerServerId(LastAttacker.Value).ToString(),
+                    VictimServerId = GetPlayerServerId(PlayerId()).ToString()
+                };
+            }
+
+            return new KillFeedClientPayload
+            {
+                AttackerServerId = null,
+                VictimServerId = GetPlayerServerId(PlayerId()).ToString(),
+            };
+        }
+    }
+}

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -513,6 +513,7 @@ namespace SurviveTheHuntClient
             }
             if(!Game.Player.IsAlive && !PlayerState.DeathReported)
             {
+                // Instead of reporting immediately, defer it for the next tick, so the KillTracker can tick to build the KillInfo.
                 PlayerState.ReportDeathNextTick = true;
             }
 

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -16,6 +16,7 @@ using static CitizenFX.Core.Native.API;
 using SharedConstants = SurviveTheHuntShared.Constants;
 using SurviveTheHuntShared.Core;
 using SurviveTheHuntShared;
+using System.Xml;
 
 namespace SurviveTheHuntClient
 {
@@ -421,6 +422,8 @@ namespace SurviveTheHuntClient
             WantedLevelHelper.DisableWantedLevel();
 
             LastSpawnTime = DateTime.UtcNow.Ticks;
+
+            KillTracker.Reset();
         }
 
         /// <summary>
@@ -494,10 +497,23 @@ namespace SurviveTheHuntClient
             PlayerState.UpdateWeapons(Game.PlayerPed);
 
             // Check and report player death to the server if needed.
+            if(PlayerState.ReportDeathNextTick)
+            {
+                TriggerServerEvent(Events.Server.PlayerDied, PlayerDiedPayload.Serialize(new PlayerDiedPayload
+                {
+                    PlayerId = Game.Player.ServerId,
+                    PlayerPosX = PlayerPos.X,
+                    PlayerPosY = PlayerPos.Y,
+                    PlayerPosZ = PlayerPos.Z,
+                    PlayerTeam = PlayerState.Team,
+                    KillInfo = KillTracker.GetKillInfo()
+                }));
+                PlayerState.DeathReported = true;
+                PlayerState.ReportDeathNextTick = false;
+            }
             if(!Game.Player.IsAlive && !PlayerState.DeathReported)
             {
-                TriggerServerEvent(Events.Server.PlayerDied, new { PlayerId = Game.Player.ServerId, PlayerPosX = PlayerPos.X, PlayerPosY = PlayerPos.Y, PlayerPosZ = PlayerPos.Z, PlayerTeam = PlayerState.Team });
-                PlayerState.DeathReported = true;
+                PlayerState.ReportDeathNextTick = true;
             }
 
             if (SpawnedVehiclesNeedSync)
@@ -565,6 +581,8 @@ namespace SurviveTheHuntClient
             TickLbgCharNeoIntegration();
 
             UpdateRelationships();
+
+            KillTracker.Tick();
 
             Wait(0);
         }

--- a/src/SurviveTheHuntClient/PlayerState.cs
+++ b/src/SurviveTheHuntClient/PlayerState.cs
@@ -26,6 +26,8 @@ namespace SurviveTheHuntClient
         /// </summary>
         public bool DeathReported { get; set; } = false;
 
+        public bool ReportDeathNextTick = false;
+
         /// <summary>
         /// Last weapon the player had equipped.
         /// </summary>

--- a/src/SurviveTheHuntClient/PlayerState.cs
+++ b/src/SurviveTheHuntClient/PlayerState.cs
@@ -26,6 +26,9 @@ namespace SurviveTheHuntClient
         /// </summary>
         public bool DeathReported { get; set; } = false;
 
+        /// <summary>
+        /// Should the player's death be reported to the server?
+        /// </summary>
         public bool ReportDeathNextTick = false;
 
         /// <summary>

--- a/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
+++ b/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CitizenFX.Core.Client, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\CitizenFX.Core.Client.1.0.6370\lib\net45\CitizenFX.Core.Client.dll</HintPath>
+      <HintPath>..\..\packages\CitizenFX.Core.Client.1.0.10230\lib\net45\CitizenFX.Core.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -48,6 +48,7 @@
     <Compile Include="Events.cs" />
     <Compile Include="GameState.cs" />
     <Compile Include="Helpers\DeathBlips.cs" />
+    <Compile Include="Helpers\KillTracker.cs" />
     <Compile Include="Helpers\MinimapHelper.cs" />
     <Compile Include="Helpers\SyncedVehicle.cs" />
     <Compile Include="Helpers\WantedLevelHelper.cs" />
@@ -60,13 +61,13 @@
     <Compile Include="Utility.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\SurviveTheHuntShared\SurviveTheHuntShared.csproj">
       <Project>{a49f7ac5-2652-4c94-930c-950f8c80283a}</Project>
       <Name>SurviveTheHuntShared</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>

--- a/src/SurviveTheHuntClient/packages.config
+++ b/src/SurviveTheHuntClient/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CitizenFX.Core.Client" version="1.0.6370" targetFramework="net452" />
+  <package id="CitizenFX.Core.Client" version="1.0.10230" targetFramework="net452" />
 </packages>

--- a/src/SurviveTheHuntServer/Events.cs
+++ b/src/SurviveTheHuntServer/Events.cs
@@ -6,6 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using static CitizenFX.Core.Native.API;
 using SurviveTheHuntShared;
+using SurviveTheHuntShared.Core;
+using SurviveTheHuntServer.Helpers;
+using System.Dynamic;
 
 namespace SurviveTheHuntServer
 {
@@ -113,6 +116,31 @@ namespace SurviveTheHuntServer
                 Debug.WriteLine($"Requesting in-game clock to be re-synced from the hunted player");
                 TriggerLatentClientEvent(GameState.Hunt.HuntedPlayer, Events.Client.ReceiveClockSyncRequest, 1);
             }
+        }
+
+        [EventHandler(Events.Server.PlayerDied)]
+        public void OnPlayerDied(string dataSerialized)
+        {
+            Debug.WriteLine(dataSerialized);
+            PlayerDiedPayload data = PlayerDiedPayload.Deserialize(dataSerialized);
+            int playerId = data.PlayerId;
+            KillFeedClientPayload killInfo = data.KillInfo;
+
+            Console.WriteLine($"Player died: {GetPlayerName($"{playerId}")}");
+
+            // Did the hunted player die?
+            if (Hunt.CheckPlayerDeath(Players[playerId], ref GameState))
+            {
+                NotifyWinner();
+                ResetTeams();
+            }
+
+            // Mark the player's death location with a blip for everyone.
+            TriggerClientEvent(Events.Client.MarkPlayerDeath, data.PlayerPosX, data.PlayerPosY, data.PlayerPosZ, data.PlayerTeam);
+
+            // Broadcast a killfeed message.
+            KillFeedServerPayload killfeedPayload = KillFeedDispatcher.GetKillFeedPayload(killInfo, GameState, RNG);
+            TriggerClientEvent(Events.Client.DisplayKill, KillFeedServerPayload.Serialize(killfeedPayload));
         }
     }
 }

--- a/src/SurviveTheHuntServer/Helpers/KillFeedDispatcher.cs
+++ b/src/SurviveTheHuntServer/Helpers/KillFeedDispatcher.cs
@@ -1,0 +1,34 @@
+﻿using SurviveTheHuntShared;
+using System;
+using SharedConstants = SurviveTheHuntShared.Constants;
+
+namespace SurviveTheHuntServer.Helpers
+{
+    internal static class KillFeedDispatcher
+    {
+        internal static KillFeedServerPayload GetKillFeedPayload(KillFeedClientPayload killInfo, GameState gameState, Random rng)
+        {
+            KillFeedServerPayload payload = new KillFeedServerPayload
+            {
+                KillInfo = killInfo,
+            };
+
+            payload.Label = SharedConstants.KillFeedMessages.FallbackLabel;
+
+            if(killInfo.AttackerServerId != null)
+            {
+                if (killInfo.VictimServerId == gameState.Hunt?.HuntedPlayer?.Handle)
+                {
+                    payload.Label = SharedConstants.KillFeedMessages.HuntedKillLabel;
+                }
+                else
+                {
+                    int randomMessage = rng.Next(SharedConstants.KillFeedMessages.RegularLabels.Length);
+                    payload.Label = SharedConstants.KillFeedMessages.RegularLabels[randomMessage];
+                }
+            }
+
+            return payload;
+        }
+    }
+}

--- a/src/SurviveTheHuntServer/Helpers/KillFeedDispatcher.cs
+++ b/src/SurviveTheHuntServer/Helpers/KillFeedDispatcher.cs
@@ -21,6 +21,10 @@ namespace SurviveTheHuntServer.Helpers
                 {
                     payload.Label = SharedConstants.KillFeedMessages.HuntedKillLabel;
                 }
+                else if(killInfo.VictimServerId == killInfo.AttackerServerId)
+                {
+                    payload.Label = SharedConstants.KillFeedMessages.SelfKillLabel;
+                }
                 else
                 {
                     int randomMessage = rng.Next(SharedConstants.KillFeedMessages.RegularLabels.Length);

--- a/src/SurviveTheHuntServer/MainScript.cs
+++ b/src/SurviveTheHuntServer/MainScript.cs
@@ -171,24 +171,6 @@ namespace SurviveTheHuntServer
                     })
                 },
                 {
-                    Events.Server.PlayerDied.EventName(), new Action<dynamic>(data =>
-                    {
-                        int playerId = data.PlayerId;
-
-                        Console.WriteLine($"Player died: {GetPlayerName($"{playerId}")}");
-
-                        // Did the hunted player die?
-                        if(Hunt.CheckPlayerDeath(Players[playerId], ref GameState))
-                        {
-                            NotifyWinner();
-                            ResetTeams();
-                        }
-
-                        // Mark the player's death location with a blip for everyone.
-                        TriggerClientEvent(Events.Client.MarkPlayerDeath, data.PlayerPosX, data.PlayerPosY, data.PlayerPosZ, data.PlayerTeam);
-                    })
-                },
-                {
                     Events.Server.RequestStartHunt.EventName(), new Action<dynamic>(data =>
                     {
                         Player randomPlayer = Hunt.ChooseRandomPlayer(Players, ref GameState);

--- a/src/SurviveTheHuntServer/SurviveTheHuntServer.csproj
+++ b/src/SurviveTheHuntServer/SurviveTheHuntServer.csproj
@@ -52,6 +52,7 @@
     <Compile Include="GameState.cs" />
     <Compile Include="Helpers\HuntedQueue.cs" />
     <Compile Include="Extensions\TeamPlugins.cs" />
+    <Compile Include="Helpers\KillFeedDispatcher.cs" />
     <Compile Include="Hunt.cs" />
     <Compile Include="MainScript.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/SurviveTheHuntShared/Constants.cs
+++ b/src/SurviveTheHuntShared/Constants.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace SurviveTheHuntShared
 {
-    public static class Constants
+    public static partial class Constants
     {
         /// <summary>
         /// Expected resource name for the gamemode on the server & client.

--- a/src/SurviveTheHuntShared/Core/PlayerDiedPayload.cs
+++ b/src/SurviveTheHuntShared/Core/PlayerDiedPayload.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SurviveTheHuntShared.Core
+{
+    public struct PlayerDiedPayload
+    {
+        public int PlayerId;
+        public float PlayerPosX, PlayerPosY, PlayerPosZ;
+        public Teams.Team PlayerTeam;
+        public KillFeedClientPayload KillInfo;
+
+        public static string Serialize(PlayerDiedPayload payload)
+        {
+            return $"{payload.PlayerId};{payload.PlayerPosX};{payload.PlayerPosY};{payload.PlayerPosZ};{(int)payload.PlayerTeam};{payload.KillInfo.AttackerServerId ?? ""};{payload.KillInfo.VictimServerId ?? ""}";
+        }
+
+        public static PlayerDiedPayload Deserialize(string serialized)
+        {
+            //Debug.WriteLine("WRITING SERIALIZED DATA");
+            //Debug.WriteLine(serialized);
+            string[] serializedParts = serialized.Split(';');
+
+            return new PlayerDiedPayload
+            {
+                PlayerId = int.Parse(serializedParts[0]),
+                PlayerPosX = float.Parse(serializedParts[1]),
+                PlayerPosY = float.Parse(serializedParts[2]),
+                PlayerPosZ = float.Parse(serializedParts[3]),
+                PlayerTeam = (Teams.Team)int.Parse(serializedParts[4]),
+                KillInfo = new KillFeedClientPayload
+                {
+                    AttackerServerId = string.IsNullOrEmpty(serializedParts[5]) ? null : serializedParts[5],
+                    VictimServerId = string.IsNullOrEmpty(serializedParts[6]) ? null : serializedParts[6],
+                }
+            };
+        }
+    }
+}

--- a/src/SurviveTheHuntShared/Events.cs
+++ b/src/SurviveTheHuntShared/Events.cs
@@ -61,6 +61,8 @@ namespace SurviveTheHuntShared
             /// The hunted player's client should receive this event before relaying the current in-game clock to a newly joined player via the server.
             /// </summary>
             public const string ReceiveClockSyncRequest = "sth:receiveHuntedClockSyncRequest";
+
+            public const string DisplayKill = "sth:displayKill";
         }
 
         /// <summary>

--- a/src/SurviveTheHuntShared/Events.cs
+++ b/src/SurviveTheHuntShared/Events.cs
@@ -62,6 +62,9 @@ namespace SurviveTheHuntShared
             /// </summary>
             public const string ReceiveClockSyncRequest = "sth:receiveHuntedClockSyncRequest";
 
+            /// <summary>
+            /// A client-side event that will run the UI functions to display a notification about a player's death.
+            /// </summary>
             public const string DisplayKill = "sth:displayKill";
         }
 

--- a/src/SurviveTheHuntShared/KillFeed.cs
+++ b/src/SurviveTheHuntShared/KillFeed.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SurviveTheHuntShared
+{
+    public struct KillFeedClientPayload
+    {
+        public string AttackerServerId;
+        public string VictimServerId;
+
+        public static string Serialize(KillFeedClientPayload data)
+        {
+            return $"{data.AttackerServerId ?? ""};{data.VictimServerId ?? ""}";
+        }
+
+        public static KillFeedClientPayload Deserialize(string serialized)
+        {
+            string[] parts = serialized.Split(';');
+            return new KillFeedClientPayload
+            {
+                AttackerServerId = parts[0],
+                VictimServerId = parts[1]
+            };
+        }
+    }
+
+    public struct KillFeedServerPayload
+    {
+        public KillFeedClientPayload KillInfo;
+        public KillFeedLabel Label;
+
+        public static string Serialize(KillFeedServerPayload data)
+        {
+            return $"{data.KillInfo.AttackerServerId ?? ""};{data.KillInfo.VictimServerId ?? ""};{data.Label.AttackerGxt};{data.Label.VictimGxt};{data.Label.WitnessGxt}"; 
+        }
+
+        public static KillFeedServerPayload Deserialize(string serializedData)
+        {
+            string[] parts = serializedData.Split(';');
+
+            return new KillFeedServerPayload
+            {
+                KillInfo = new KillFeedClientPayload
+                {
+                    AttackerServerId = parts[0],
+                    VictimServerId = parts[1]
+                },
+                Label = new KillFeedLabel
+                {
+                    AttackerGxt = parts[2],
+                    VictimGxt = parts[3],
+                    WitnessGxt = parts[4]
+                }
+            };
+        }
+    }
+
+    public struct KillFeedLabel
+    {
+        public string AttackerGxt;
+        public string VictimGxt;
+        public string WitnessGxt;
+
+        /// <summary>
+        /// This returns either 0, 1, or 2 depending on how many player names need to be inserted into the text.
+        /// </summary>
+        /// <param name="gxtText">Text from the loaded GXT label.</param>
+        /// <returns></returns>
+        public static byte CountPlayerNames(string gxtText)
+        {
+            if (gxtText != null)
+            {
+                const string playerPlaceholder = "~a~";
+                int index = gxtText.IndexOf(playerPlaceholder);
+                if (index != -1)
+                {
+                    if (index != gxtText.LastIndexOf(playerPlaceholder))
+                    {
+                        return 2;
+                    }
+
+                    return 1;
+                }
+            }
+
+            return 0;
+        }
+    }
+
+    public static partial class Constants
+    {
+        public static class KillFeedMessages
+        {
+            public static KillFeedLabel[] RegularLabels =
+            {
+                new KillFeedLabel{AttackerGxt = "DM_TICK2", VictimGxt = "DM_TICK1", WitnessGxt = "DM_TICK6"}
+            };
+
+            public static KillFeedLabel SelfKillLabel = new KillFeedLabel { AttackerGxt = "DM_O_SUIC", WitnessGxt = "DM_O_SUIC", VictimGxt = "DM_U_SUIC" };
+
+            public static KillFeedLabel FallbackLabel = new KillFeedLabel { VictimGxt = "DM_TK_YD1", AttackerGxt = "TICK_DIED", WitnessGxt = "TICK_DIED" };
+
+            public static KillFeedLabel HuntedKillLabel = new KillFeedLabel { WitnessGxt = "FM_TGDM_KIL", AttackerGxt = "FM_TGDM_KIL", VictimGxt = "FM_TGDM_KIL" };
+        }
+    }
+}

--- a/src/SurviveTheHuntShared/SurviveTheHuntShared.csproj
+++ b/src/SurviveTheHuntShared/SurviveTheHuntShared.csproj
@@ -46,10 +46,12 @@
   <ItemGroup>
     <Compile Include="Constants.cs" />
     <Compile Include="Core\Config.cs" />
+    <Compile Include="Core\PlayerDiedPayload.cs" />
     <Compile Include="Core\VehicleWhitelist.cs" />
     <Compile Include="Core\Teams.cs" />
     <Compile Include="Core\WeaponLoadout.cs" />
     <Compile Include="Events.cs" />
+    <Compile Include="KillFeed.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\ConvarHelper.cs" />
     <Compile Include="Utils\Coord.cs" />


### PR DESCRIPTION
This PR adds a killfeed to the gamemode's UI; every time a player dies, a notification is relayed to all clients via a server event. The localised GTAV MP death GXT labels are used for the text. This helps to keep the players informed about their teammates' status.

Closes #73