### PR TITLE
fix: fixed weapon attachments being lost on ped change

### DIFF
--- a/src/SurviveTheHuntClient/Helpers/NativeHelpers.cs
+++ b/src/SurviveTheHuntClient/Helpers/NativeHelpers.cs
@@ -1,0 +1,17 @@
+﻿using SurviveTheHuntShared.Utils;
+using static CitizenFX.Core.Native.API;
+
+namespace SurviveTheHuntClient.Helpers
+{
+    internal static class NativeHelpers
+    {
+        internal static void GivePedWeapon(int pedHandle, Weapons.WeaponAmmo weapon, bool equip = false)
+        {
+            GiveWeaponToPed(pedHandle, weapon.Hash, weapon.Ammo, false, equip);
+            foreach(string attachment in weapon.Attachments)
+            {
+                WeaponAttachments.ApplyAttachment(weapon.Hash, attachment);
+            }
+        }
+    }
+}

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -726,6 +726,7 @@ namespace SurviveTheHuntClient
             }
 
             PlayerState.TakeAwayWeapons(ref playerPed);
+            AmmoCheckTimer = 0;
         }
 
         private void HuntStartedByServer(float secondsTillPing, DateTime endTime, TimeSpan? prepPhase = null)
@@ -953,7 +954,7 @@ namespace SurviveTheHuntClient
                 foreach (Weapons.WeaponAmmo weapon in AmmoState)
                 {
                     Debug.WriteLine($"Setting {weapon.Hash} to have {weapon.Ammo} ammo");
-                    GiveWeaponToPed(playerPed, weapon.Hash, weapon.Ammo, false, false);
+                    NativeHelpers.GivePedWeapon(playerPed, weapon);
                 }
             }
 

--- a/src/SurviveTheHuntClient/PlayerState.cs
+++ b/src/SurviveTheHuntClient/PlayerState.cs
@@ -121,12 +121,7 @@ namespace SurviveTheHuntClient
             foreach(Weapons.WeaponAmmo weapon in Constants.WeaponLoadouts[Team])
             {
                 bool equip = weapon.Hash == LastWeaponEquipped;
-                GiveWeaponToPed(playerPed.Handle, weapon.Hash, weapon.Ammo, false, equip);
-                
-                foreach(string attachment in weapon.Attachments)
-                {
-                    WeaponAttachments.ApplyAttachment(weapon.Hash, attachment);
-                }
+                NativeHelpers.GivePedWeapon(playerPed.Handle, weapon, equip);
             }
 
             WeaponsGiven = true;

--- a/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
+++ b/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Helpers\DeathBlips.cs" />
     <Compile Include="Helpers\KillTracker.cs" />
     <Compile Include="Helpers\MinimapHelper.cs" />
+    <Compile Include="Helpers\NativeHelpers.cs" />
     <Compile Include="Helpers\SyncedVehicle.cs" />
     <Compile Include="Helpers\WantedLevelHelper.cs" />
     <Compile Include="Helpers\WeaponAttachments.cs" />

--- a/src/SurviveTheHuntServer/GameState.cs
+++ b/src/SurviveTheHuntServer/GameState.cs
@@ -44,6 +44,12 @@ namespace SurviveTheHuntServer
             public DateTime EndTime { get { return StartTime + SharedConstants.HuntDuration + EndTimeOffset; } }
 
             /// <summary>
+            /// UTC time when the next hunt can be started (this is to induce a cooldown so client scripts can catch up - yes it's gash but otherwise wrong weapon loadouts can be given out)
+            /// If null, this means the hunt can be started right now.
+            /// </summary>
+            public DateTime? NextHuntStartTime = null;
+
+            /// <summary>
             /// UTC time of last time the hunted player was pinged on the map.
             /// </summary>
             public DateTime LastPingTime { get; set; } = DateTime.UtcNow;
@@ -82,6 +88,7 @@ namespace SurviveTheHuntServer
                 WinningTeam = winningTeam;
                 IsStarted = false;
                 HuntedPlayer = null;
+                NextHuntStartTime = DateTime.UtcNow + TimeSpan.FromMilliseconds(SharedConstants.HuntStartCooldown);
             }
         }
 

--- a/src/SurviveTheHuntServer/MainScript.cs
+++ b/src/SurviveTheHuntServer/MainScript.cs
@@ -173,6 +173,12 @@ namespace SurviveTheHuntServer
                 {
                     Events.Server.RequestStartHunt.EventName(), new Action<dynamic>(data =>
                     {
+                        // Prevent the next hunt from being started too quick.
+                        if(GameState.Hunt.NextHuntStartTime != null && GameState.Hunt.NextHuntStartTime > DateTime.UtcNow)
+                        {
+                            return;
+                        }
+
                         Player randomPlayer = Hunt.ChooseRandomPlayer(Players, ref GameState);
 
                         GameState.Hunt.LastHuntedPlayer = randomPlayer;

--- a/src/SurviveTheHuntShared/Constants.cs
+++ b/src/SurviveTheHuntShared/Constants.cs
@@ -267,5 +267,11 @@ namespace SurviveTheHuntShared
         /// If true, the hunter players' in-game clocks will be synced with the hunted player's in-game time when the hunt starts.
         /// </summary>
         public const string SyncTimeOnHuntStartConvar = "sth_syncTimeOnHuntStart";
+
+
+        /// <summary>
+        /// Number of milliseconds to wait before allowing a hunt to be started again.
+        /// </summary>
+        public const ushort HuntStartCooldown = 10 * 1000;
     }
 }


### PR DESCRIPTION
This PR fixes an issue where the weapon attachments would not be re-applied when the weapons were being given back to the player after their ped model changed.

Also fixes wrong weapon loadout being given to the hunted player if the next hunt starts too soon after the previous one finished ( there is now a 10s cooldown)

Closes #80