### PR TITLE
fix(client): fixed cars not being cleaned up on resource restart

### DIFF
--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -95,7 +95,7 @@ namespace SurviveTheHuntClient
         {
             EventHandlers["onClientGameTypeStart"] += new Action<string>(OnClientGameTypeStart);
             EventHandlers["onClientResourceStart"] += new Action<string>(OnClientResourceStart);
-            EventHandlers["onResourceStopping"] += new Action<string>(OnResourceStopping);
+            EventHandlers["onResourceStop"] += new Action<string>(OnResourceStopping);
 
             CreateEvents();
             foreach(KeyValuePair<string, Action<dynamic>> ev in STHEvents)


### PR DESCRIPTION
This PR fixes an issue where the spawned cars would not be deleted when the resource was stopped, and would carry on to the next instance of the script, except the handles were lost so that instance couldn't clean them up neither.

This was caused by a wrong event name, so it may also fix some other issues with regards to resource restarts

Closes #82 