### PR TITLE
fix(client/ui): fixed appearance submenu not returning to the main menu

### DIFF
--- a/src/SurviveTheHuntClient.UI/MainScript.cs
+++ b/src/SurviveTheHuntClient.UI/MainScript.cs
@@ -41,6 +41,8 @@ namespace SurviveTheHuntClient.UI
         private bool HoldingInteractionMenuPadButton = false;
         private float TimeHoldingInteractionMenu = 0f;
 
+        private const string ShowMenuEventName = "sth:client:ui:showMenu";
+
         public MainScript()
         {
             EventHandlers["onClientResourceStart"] += new Action<string>(OnClientGameTypeStart);
@@ -177,7 +179,7 @@ namespace SurviveTheHuntClient.UI
         private void CharacterMenuClicked(object sender, EventArgs e)
         {
             MainMenu.Visible = false;
-            TriggerEvent("lbg-openChar");
+            TriggerEvent("lbg-openChar", ShowMenuEventName);
         }
 
         private void StartHuntClicked(object sender, EventArgs e)
@@ -208,7 +210,7 @@ namespace SurviveTheHuntClient.UI
             MainMenu.Visible = Shown;
         }
 
-        [EventHandler("sth:client:ui:showMenu")]
+        [EventHandler(ShowMenuEventName)]
         private void ShowMenu()
         {
             Shown = true;


### PR DESCRIPTION
This PR fixes an issue where, if lbg-char-neo is used, its menu would not return control back to the main menu when it's closed - instead the menu would close and the user would have to reopen it again