### PR TITLE
feat(ui): added area blip and notification for approaching play area limits

### DIFF
--- a/src/SurviveTheHuntClient.UI/Properties/AssemblyInfo.cs
+++ b/src/SurviveTheHuntClient.UI/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/src/SurviveTheHuntClient/Helpers/BoundsTracker.cs
+++ b/src/SurviveTheHuntClient/Helpers/BoundsTracker.cs
@@ -1,0 +1,80 @@
+﻿using CitizenFX.Core;
+using System;
+using static CitizenFX.Core.Native.API;
+using SharedConstants = SurviveTheHuntShared.Constants;
+
+namespace SurviveTheHuntClient.Helpers
+{
+    internal static class BoundsTracker
+    {
+        private static int? PlayAreaBlip = null;
+        private static bool WasApproachingBoundsLastTick = false;
+        private const int ApproachingOutOfBoundsNotificationDuration = 20;
+        private static float TimePassedSinceLastOOBNotification = 0;
+
+        internal static void Init()
+        {
+            const float yOffset = 0f;
+            PlayAreaBlip = AddBlipForArea(-100f , (SharedConstants.DockSpawn.Y + SharedConstants.OutOfBoundsYLimit) * .5f + yOffset, SharedConstants.DockSpawn.Z, 4250f, Math.Abs(SharedConstants.OutOfBoundsYLimit - SharedConstants.DockSpawn.Y) + Math.Abs(yOffset) * .5f);
+            SetBlipDisplay(PlayAreaBlip.Value, 0);
+            uint colour = 0xFFA83366;
+            SetBlipColour(PlayAreaBlip.Value, (int)colour);
+        }
+
+        internal static void Tick()
+        {
+            bool approachingBounds = CheckIsApproachingBounds();
+            if (approachingBounds != WasApproachingBoundsLastTick && PlayAreaBlip.HasValue)
+            {
+                SetBlipDisplay(PlayAreaBlip.Value, approachingBounds ? 10 : 0);
+
+                if (approachingBounds && TimePassedSinceLastOOBNotification == 0)
+                {
+                    const string warningText = "ApproachingOutOfBoundsNotification";
+                    AddTextEntry(warningText, "You are approaching the ~o~play area~w~ limits. If you leave the area marked in orange, you will appear on the hunters' radar.~n~~n~Try make your way back further into the ~o~play area~w~ to avoid detection.");
+                    BeginTextCommandDisplayHelp(warningText);
+                    EndTextCommandDisplayHelp(0, false, true, ApproachingOutOfBoundsNotificationDuration * 1000);
+
+                    TimePassedSinceLastOOBNotification = GetFrameTime();
+                }
+            }
+
+            // Debounce the notification
+            if(TimePassedSinceLastOOBNotification != 0)
+            {
+                if (TimePassedSinceLastOOBNotification >= ApproachingOutOfBoundsNotificationDuration)
+                {
+                    TimePassedSinceLastOOBNotification = 0;
+                }
+                else
+                {
+                    TimePassedSinceLastOOBNotification += GetFrameTime();
+                }
+            }
+
+            SetBlipRotation(PlayAreaBlip.Value, 0);
+
+            WasApproachingBoundsLastTick = approachingBounds;
+        }
+
+        private static bool CheckIsApproachingBounds()
+        {
+            // Distance inside the bounds at which the player should be notified.
+            const float margin = 250f;
+
+            int localPlayerPed = PlayerPedId();
+            if (DoesEntityExist(localPlayerPed))
+            {
+                // TODO: when we finally get to implementing #55 (configurable play areas),
+                // this will not work because it only does a 1D check against the player's Y-coord. But that's good enough for now.
+                Vector3 pos = GetEntityCoords(localPlayerPed, false);
+                if(pos.Y >= SharedConstants.OutOfBoundsYLimit - margin)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/SurviveTheHuntClient/Helpers/BoundsTracker.cs
+++ b/src/SurviveTheHuntClient/Helpers/BoundsTracker.cs
@@ -5,6 +5,10 @@ using SharedConstants = SurviveTheHuntShared.Constants;
 
 namespace SurviveTheHuntClient.Helpers
 {
+    /// <summary>
+    /// Helper class that runs logic for checking the local player's proximity to play area limits
+    /// and displaying the appropriate UI elements to help them avoid detection.
+    /// </summary>
     internal static class BoundsTracker
     {
         private static int? PlayAreaBlip = null;

--- a/src/SurviveTheHuntClient/HuntUI.cs
+++ b/src/SurviveTheHuntClient/HuntUI.cs
@@ -410,7 +410,6 @@ namespace SurviveTheHuntClient
                 if(player == Game.Player)
                 {
                     SetBlipColour(GetMainPlayerBlipId(), player.Handle + 10);
-                    continue;
                 }
 
                 // Creates overhead player name labels if need be.
@@ -418,6 +417,12 @@ namespace SurviveTheHuntClient
                 {
                     //Debug.WriteLine($"Creating GamerTag for {player.Name}");
                     CreateMpGamerTagWithCrewColor(player.Handle, player.Name, false, false, "", 0, 0, 0, 0);
+                }
+
+                if(player == Game.Player)
+                {
+                    SetMpGamerTagColour(player.Handle, 0, GetBlipHudColour(GetMainPlayerBlipId()));
+                    continue;
                 }
 
                 if (!PlayerBlips.ContainsKey(player.Character.Handle))
@@ -451,6 +456,9 @@ namespace SurviveTheHuntClient
             N_0x82cedc33687e1f50(true);
 
             List<int> pedsToDelete = new List<int>();
+
+            // Show the local player's overhead name if they're outside the play area.
+            SetMpGamerTagVisibility(Game.Player.Handle, 0, gameState.Hunt.IsStarted && GameState.IsPedTooFar(Game.PlayerPed));
 
             foreach(int ped in PlayerBlips.Keys)
             {

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -229,6 +229,8 @@ namespace SurviveTheHuntClient
                 SetBlipColour(SafeZoneRadiusBlipHandle, 69);
                 SetBlipAlpha(SafeZoneRadiusBlipHandle, 128);
                 SetBlipDisplay(SafeZoneRadiusBlipHandle, 6);
+
+                BoundsTracker.Init();
             }
         }
 
@@ -590,6 +592,8 @@ namespace SurviveTheHuntClient
             UpdateRelationships();
 
             KillTracker.Tick();
+
+            BoundsTracker.Tick();
 
             Wait(0);
         }

--- a/src/SurviveTheHuntClient/Properties/AssemblyInfo.cs
+++ b/src/SurviveTheHuntClient/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
+++ b/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
@@ -47,6 +47,7 @@
     <Compile Include="Constants.cs" />
     <Compile Include="Events.cs" />
     <Compile Include="GameState.cs" />
+    <Compile Include="Helpers\BoundsTracker.cs" />
     <Compile Include="Helpers\DeathBlips.cs" />
     <Compile Include="Helpers\KillTracker.cs" />
     <Compile Include="Helpers\MinimapHelper.cs" />

--- a/src/SurviveTheHuntServer/Properties/AssemblyInfo.cs
+++ b/src/SurviveTheHuntServer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]

--- a/src/SurviveTheHuntShared/Properties/AssemblyInfo.cs
+++ b/src/SurviveTheHuntShared/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyVersion("1.4.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]


### PR DESCRIPTION
This PR adds an on-screen notification warning the player when they approach Los Santos limits, telling them to go back. A semitransparent area blip is displayed on the radar to instruct the player of the valid play area bounds.

https://github.com/user-attachments/assets/524eb037-1229-4632-8741-c7dc9a691d22




Closes #86