### PR TITLE
feat(client): allows hunted player to driveby as passenger

### DIFF
--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -516,6 +516,8 @@ namespace SurviveTheHuntClient
             HuntUI.FadeBlips();
             HuntUI.UpdateTeammateBlips(Players, ref GameState, ref PlayerState);
 
+            // PlayerPassenger needs to tick before the weapons are updated because we need to check if the hunted player can driveby.
+            PlayerPassenger.Tick();
             PlayerState.UpdateWeapons(Game.PlayerPed);
 
             // Check and report player death to the server if needed.
@@ -608,8 +610,6 @@ namespace SurviveTheHuntClient
             KillTracker.Tick();
 
             BoundsTracker.Tick();
-
-            PlayerPassenger.Tick();
 
             Wait(0);
         }

--- a/src/SurviveTheHuntClient/PlayerState.cs
+++ b/src/SurviveTheHuntClient/PlayerState.cs
@@ -140,7 +140,8 @@ namespace SurviveTheHuntClient
             }
 
             // Weapons aren't allowed in vehicles.
-            bool weaponsAllowed = !playerPed.IsGettingIntoAVehicle && !playerPed.IsInVehicle();
+            // However, the hunted player should be able to driveby if they're a passenger.
+            bool weaponsAllowed = (!playerPed.IsGettingIntoAVehicle && !playerPed.IsInVehicle()) || (Team == Teams.Team.Hunted && playerPed.SeatIndex >= 0);
 
             // If the player has a weapon equipped, store the weapon in LastWeaponEquipped so we keep track in case we need to re-equip it.
             if(weaponsAllowed && !ForcedUnarmed)
@@ -153,12 +154,14 @@ namespace SurviveTheHuntClient
             if (!weaponsAllowed && !ForcedUnarmed)
             {
                 SetCurrentPedWeapon(playerPed.Handle, (uint)WeaponHash.Unarmed, true);
-                SetPedCanSwitchWeapon(playerPed.Handle, false);
                 ForcedUnarmed = true;
             }
 
+            // Allow the hunted player to change their weapon as a passenger.
+            SetPedCanSwitchWeapon(playerPed.Handle, weaponsAllowed);
+
             // Revert the above, automatically equipping the player's last used weapon, if weapons are now allowed.
-            if(ForcedUnarmed && weaponsAllowed)
+            if (ForcedUnarmed && weaponsAllowed)
             {
                 SetCurrentPedWeapon(playerPed.Handle, LastWeaponEquipped, true);
                 SetPedCanSwitchWeapon(playerPed.Handle, true);


### PR DESCRIPTION
This PR adds the ability for hunted players to use their weapons when in the passenger seat.

https://github.com/user-attachments/assets/240d44e3-3491-4566-a36b-918819b758bb

Closes #96