### PR TITLE
feat(client): added a "wasted" visual & audio effect on player death

### DIFF
--- a/src/SurviveTheHuntClient/Helpers/KillTracker.cs
+++ b/src/SurviveTheHuntClient/Helpers/KillTracker.cs
@@ -40,7 +40,6 @@ namespace SurviveTheHuntClient.Helpers
                 if(currentAttacker != 0)
                 {
                     LastAttacker = NetworkGetPlayerIndexFromPed(currentAttacker);
-                    Debug.WriteLine($"Attacker: {GetPlayerName(LastAttacker.Value)}");
                 }
                 else if(TimeSinceLastDamage >= AttackerTimeout || currentHealth < LastTickHealth)
                 {

--- a/src/SurviveTheHuntClient/Helpers/WastedAnim.cs
+++ b/src/SurviveTheHuntClient/Helpers/WastedAnim.cs
@@ -1,0 +1,90 @@
+﻿using CitizenFX.Core;
+using static CitizenFX.Core.Native.API;
+
+namespace SurviveTheHuntClient.Helpers
+{
+    internal static class WastedAnim
+    {
+        private static bool NeedsToPlayWastedScaleform = false;
+        private const string GfxName = "generic";
+        private const string ScaleformName = "MP_BIG_MESSAGE_FREEMODE";
+        private const string MethodName = "SHOW_SHARD_WASTED_MP_MESSAGE";
+
+        private static int? ScaleformHandle = null;
+        private static bool ShouldShow = false;
+
+        private const float SecondsTillShard = 0.15f;
+        private static float SecondsPassedSinceDeath = 0f;
+        private static int? CurrentSoundId = null;
+
+        internal static void NotifyDeath()
+        {
+            NeedsToPlayWastedScaleform = true;
+            ShouldShow = true;
+            if (!ScaleformHandle.HasValue || !HasScaleformMovieLoaded(ScaleformHandle.Value))
+            {
+                ScaleformHandle = RequestScaleformMovie(ScaleformName);
+            }
+            SecondsPassedSinceDeath = 0f;
+
+            if(CurrentSoundId.HasValue)
+            {
+                ReleaseSoundId(CurrentSoundId.Value);
+            }
+            CurrentSoundId = GetSoundId();
+            PlaySoundFrontend(CurrentSoundId.Value, "MP_Flash", "WastedSounds", true);
+        }
+
+        internal static void StopShowing()
+        {
+            ShouldShow = false;
+            NeedsToPlayWastedScaleform = false;
+        }
+
+        internal static void Tick()
+        {
+            if(NeedsToPlayWastedScaleform && ScaleformHandle.HasValue && HasScaleformMovieLoaded(ScaleformHandle.Value))
+            {
+                Debug.WriteLine("Playing scaleform!");
+                NeedsToPlayWastedScaleform = false;
+                BeginScaleformMovieMethod(ScaleformHandle.Value, MethodName);
+                PushScaleformMovieMethodParameterString(GetLabelText("RESPAWN_W"));
+                PushScaleformMovieMethodParameterString("");
+                PushScaleformMovieMethodParameterInt(13);
+                PushScaleformMovieMethodParameterBool(false);
+                PushScaleformMovieMethodParameterBool(true);
+                EndScaleformMovieMethod();
+                ShouldShow = true;
+
+                AnimpostfxPlay("DeathFailOut", 0, true);
+
+                ShakeGameplayCam("DEATH_FAIL_IN_EFFECT_SHAKE", 0.75f);
+            }
+
+            if (ShouldShow)
+            {
+                if (ScaleformHandle.HasValue && SecondsPassedSinceDeath >= SecondsTillShard)
+                {
+                    DrawScaleformMovieFullscreen(ScaleformHandle.Value, 255, 255, 255, 255, 0);
+                }
+
+                SecondsPassedSinceDeath += GetFrameTime();
+            }
+
+            if(IsScreenFadingIn())
+            {
+                ShouldShow = false;
+                SecondsPassedSinceDeath = 0f;
+                AnimpostfxStop("DeathFailOut");
+                StopGameplayCamShaking(true);
+            }
+
+            if(!ShouldShow && CurrentSoundId.HasValue)
+            {
+                StopSound(CurrentSoundId.Value);
+                ReleaseSoundId(CurrentSoundId.Value);
+                CurrentSoundId = null;
+            }
+        }
+    }
+}

--- a/src/SurviveTheHuntClient/Helpers/WastedAnim.cs
+++ b/src/SurviveTheHuntClient/Helpers/WastedAnim.cs
@@ -13,7 +13,7 @@ namespace SurviveTheHuntClient.Helpers
         private static int? ScaleformHandle = null;
         private static bool ShouldShow = false;
 
-        private const float SecondsTillShard = 0.15f;
+        private const float SecondsTillShard = 0.4f;
         private static float SecondsPassedSinceDeath = 0f;
         private static int? CurrentSoundId = null;
 

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -446,6 +446,8 @@ namespace SurviveTheHuntClient
             LastSpawnTime = DateTime.UtcNow.Ticks;
 
             KillTracker.Reset();
+
+            WastedAnim.StopShowing();
         }
 
         /// <summary>
@@ -534,6 +536,8 @@ namespace SurviveTheHuntClient
                 }));
                 PlayerState.DeathReported = true;
                 PlayerState.ReportDeathNextTick = false;
+
+                WastedAnim.NotifyDeath();
             }
             if(!Game.Player.IsAlive && !PlayerState.DeathReported)
             {
@@ -608,8 +612,8 @@ namespace SurviveTheHuntClient
             UpdateRelationships();
 
             KillTracker.Tick();
-
             BoundsTracker.Tick();
+            WastedAnim.Tick();
 
             Wait(0);
         }

--- a/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
+++ b/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Helpers\PlayerPassenger.cs" />
     <Compile Include="Helpers\SyncedVehicle.cs" />
     <Compile Include="Helpers\WantedLevelHelper.cs" />
+    <Compile Include="Helpers\WastedAnim.cs" />
     <Compile Include="Helpers\WeaponAttachments.cs" />
     <Compile Include="HuntUI.cs" />
     <Compile Include="Integrations\LbgCharNeo.cs" />


### PR DESCRIPTION
This PR implements the "wasted" effect from regular GTA when the player dies. It's not an exact match but the text shard, post fx, camera shake and audio are present. Respawns in Survive the Hunt are generally quicker than GTAO so it may seem a bit jarring how quickly it fades, but it's better than not having any player death feedback at all.

https://github.com/user-attachments/assets/09c85d50-12bc-4aa9-adc7-fb6dfe7fc961

Closes #97