### PR TITLE
fix: fixed multiple clients being able to spawn cars at the same time

### DIFF
--- a/src/SurviveTheHuntClient/Events.cs
+++ b/src/SurviveTheHuntClient/Events.cs
@@ -3,6 +3,7 @@ using System;
 using Events = SurviveTheHuntShared.Events;
 using static CitizenFX.Core.Native.API;
 using SurviveTheHuntShared;
+using System.Threading.Tasks;
 
 namespace SurviveTheHuntClient
 {
@@ -68,6 +69,16 @@ namespace SurviveTheHuntClient
             }
 
             EndTextCommandThefeedPostMpticker(true, true);
+        }
+
+        [EventHandler(Events.Client.ReceiveVehicleSpawnPermission)]
+        public void VehicleSpawnPermissionReceived(bool canSpawn)
+        {
+            if (!IsSpawningCars && canSpawn)
+            {
+                IsSpawningCars = true;
+                SpawnCars();
+            }
         }
     }
 }

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -179,14 +179,9 @@ namespace SurviveTheHuntClient
                     TriggerServerEvent(Events.Server.RequestStartHunt);
                 }), false);
 
-                Action spawnCarsAction = new Action(async () =>
+                Action spawnCarsAction = new Action(() =>
                 {
-                    if (!IsSpawningCars)
-                    {
-                        IsSpawningCars = true;
-                        await SpawnCars();
-                        IsSpawningCars = false;
-                    }
+                    TriggerServerEvent(Events.Server.RequestSpawnVehiclesPermission);
                 });
                 RegisterCommand("spawncars", spawnCarsAction, false);
                 EventHandlers[Events.Client.SpawnCars] += spawnCarsAction;
@@ -384,6 +379,9 @@ namespace SurviveTheHuntClient
                 counter++;
             }
             SpawnedVehiclesNeedSync = true;
+
+            IsSpawningCars = false;
+            TriggerServerEvent(Events.Server.NotifySpawnedVehicles);
         }
 
         protected void AutoSpawnCallback()

--- a/src/SurviveTheHuntServer/Events.cs
+++ b/src/SurviveTheHuntServer/Events.cs
@@ -36,6 +36,33 @@ namespace SurviveTheHuntServer
             SyncVehicles(SpawnedVehicles);
         }
 
+        [EventHandler(Events.Server.RequestSpawnVehiclesPermission)]
+        public void VehicleSpawnRequested([FromSource] Player player)
+        {
+            Debug.WriteLine($"{player.Name} is requesting to spawn cars");
+            bool canSpawn = CarSpawner.RequestSpawn(player.Handle);
+            if(canSpawn)
+            {
+                Debug.WriteLine($"{player.Name} (server ID {player.Handle}) is allowed to spawn cars, will time out in {CarSpawner.SpawnLockTimeoutSeconds}s");
+            }
+            else
+            {
+                Debug.WriteLine($"{player.Name} (server ID {player.Handle}) is not allowed to spawn cars as someone else is currently spawning.");
+            }
+
+            TriggerClientEvent(player, Events.Client.ReceiveVehicleSpawnPermission, canSpawn);
+        }
+
+        [EventHandler(Events.Server.NotifySpawnedVehicles)]
+        public void AcknowledgeSpawnedVehicles([FromSource] Player player)
+        {
+            bool unlocked = CarSpawner.Unlock(player.Handle);
+            if(unlocked)
+            {
+                Debug.WriteLine($"{player.Name} (server ID {player.Handle} has finished spawning vehicles");
+            }
+        }
+
         [EventHandler(Events.Server.RequestSyncVehicles)]
         public void SyncVehiclesRequested([FromSource] Player player, string vehicleNetIdsPacked)
         {

--- a/src/SurviveTheHuntServer/Helpers/CarSpawner.cs
+++ b/src/SurviveTheHuntServer/Helpers/CarSpawner.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SurviveTheHuntServer.Helpers
+{
+    /// <summary>
+    /// A helper class to lock the car spawning logic for clients while another client is already spawning cars.
+    /// </summary>
+    internal static class CarSpawner
+    {
+        private static string _currentSpawner = null;
+
+        /// <summary>
+        /// Time when the current spawner's "lock" expires
+        /// </summary>
+        private static DateTime _nextSpawnUnlock = DateTime.UtcNow;
+
+        public const ushort SpawnLockTimeoutSeconds = 15;
+
+        internal static bool RequestSpawn(string playerHandle)
+        {
+            if(_currentSpawner == null || _nextSpawnUnlock < DateTime.UtcNow)
+            {
+                _currentSpawner = playerHandle;
+                _nextSpawnUnlock = DateTime.UtcNow.AddSeconds(SpawnLockTimeoutSeconds);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        internal static bool Unlock(string playerHandle)
+        {
+            if(_currentSpawner == playerHandle)
+            {
+                _currentSpawner = null;
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/SurviveTheHuntServer/SurviveTheHuntServer.csproj
+++ b/src/SurviveTheHuntServer/SurviveTheHuntServer.csproj
@@ -50,6 +50,7 @@
     <Compile Include="Constants.cs" />
     <Compile Include="Events.cs" />
     <Compile Include="GameState.cs" />
+    <Compile Include="Helpers\CarSpawner.cs" />
     <Compile Include="Helpers\HuntedQueue.cs" />
     <Compile Include="Extensions\TeamPlugins.cs" />
     <Compile Include="Helpers\KillFeedDispatcher.cs" />

--- a/src/SurviveTheHuntShared/Events.cs
+++ b/src/SurviveTheHuntShared/Events.cs
@@ -70,6 +70,8 @@ namespace SurviveTheHuntShared
             public const string SpawnCars = "sth:spawnCars";
             public const string Heal = "sth:heal";
             public const string Respawn = "sth:respawn";
+
+            public const string ReceiveVehicleSpawnPermission = "sth:recvSpawnVehiclesPerm";
         }
 
         /// <summary>
@@ -81,6 +83,8 @@ namespace SurviveTheHuntShared
             public const string RequestDeleteVehicle = "sth:reqDeleteVehicle";
             public const string PlayerDied = "sth:playerDied";
             public const string BroadcastHuntedZone = "sth:broadcastHuntedZone";
+            public const string RequestSpawnVehiclesPermission = "sth:reqSpawnVehicles";
+            public const string NotifySpawnedVehicles = "sth:ackSpawnedVehicles";
             public const string RequestSyncVehicles = "sth:reqSyncVehicles";
             public const string ClientStarted = "sth:clientStarted";
             public const string RequestStartHunt = "sth:startHunt";


### PR DESCRIPTION
This PR fixes an issue where, if two players clicked "Spawn cars" before the cars fully spawned, two batches of vehicles would spawn on top of one another, and they'd be unable to remove them.

Now the clients have to obtain a lock from the server before they invoke the spawning logic, preventing them from spawning vehicles at the same time.

Closes #103