### PR TITLE
fix(client): fixed passenger seat weaponised vehicle exploit

### DIFF
--- a/src/SurviveTheHuntClient/Helpers/VehicleWeaponsTracker.cs
+++ b/src/SurviveTheHuntClient/Helpers/VehicleWeaponsTracker.cs
@@ -1,0 +1,26 @@
+﻿using CitizenFX.Core;
+using static CitizenFX.Core.Native.API;
+
+namespace SurviveTheHuntClient.Helpers
+{
+    /// <summary>
+    /// Helper for disabling weaponised vehicles' guns
+    /// </summary>
+    internal static class VehicleWeaponsTracker
+    {
+        internal static void Tick()
+        {
+            Vehicle veh = Game.PlayerPed.CurrentVehicle;
+            if(veh?.Exists() == true && DoesVehicleHaveWeapons(veh.Handle))
+            {
+                uint weapon = uint.MaxValue;
+
+                // If the player ped has a vehicle weapon equipped, disable it
+                if(GetCurrentPedVehicleWeapon(Game.PlayerPed.Handle, ref weapon))
+                {
+                    DisableVehicleWeapon(true, weapon, veh.Handle, Game.PlayerPed.Handle);
+                }
+            }
+        }
+    }
+}

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -612,6 +612,7 @@ namespace SurviveTheHuntClient
             KillTracker.Tick();
             BoundsTracker.Tick();
             WastedAnim.Tick();
+            VehicleWeaponsTracker.Tick();
 
             Wait(0);
         }

--- a/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
+++ b/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Helpers\PlayerPassenger.cs" />
     <Compile Include="Helpers\SyncedVehicle.cs" />
     <Compile Include="Helpers\WantedLevelHelper.cs" />
+    <Compile Include="Helpers\VehicleWeaponsTracker.cs" />
     <Compile Include="Helpers\WastedAnim.cs" />
     <Compile Include="Helpers\WeaponAttachments.cs" />
     <Compile Include="HuntUI.cs" />


### PR DESCRIPTION
Closes #106 

To test, change vehicles.json to be just a bunch of `ardent` entries. Enter through the passenger seat, guns shouldn't be usable.