### PR TITLE
fix(client): fixed weaponised vehicles appearing as firing weapons on other clients

### DIFF
--- a/src/SurviveTheHuntClient/Helpers/BoundsTracker.cs
+++ b/src/SurviveTheHuntClient/Helpers/BoundsTracker.cs
@@ -1,4 +1,5 @@
 ﻿using CitizenFX.Core;
+using SurviveTheHuntClient.Interfaces;
 using System;
 using static CitizenFX.Core.Native.API;
 using SharedConstants = SurviveTheHuntShared.Constants;
@@ -9,14 +10,14 @@ namespace SurviveTheHuntClient.Helpers
     /// Helper class that runs logic for checking the local player's proximity to play area limits
     /// and displaying the appropriate UI elements to help them avoid detection.
     /// </summary>
-    internal static class BoundsTracker
+    internal class BoundsTracker : ITickable
     {
-        private static int? PlayAreaBlip = null;
-        private static bool WasApproachingBoundsLastTick = false;
+        private int? PlayAreaBlip = null;
+        private bool WasApproachingBoundsLastTick = false;
         private const int ApproachingOutOfBoundsNotificationDuration = 20;
-        private static float TimePassedSinceLastOOBNotification = 0;
+        private float TimePassedSinceLastOOBNotification = 0;
 
-        internal static void Init()
+        internal void Init()
         {
             const float yOffset = 0f;
             PlayAreaBlip = AddBlipForArea(-100f , (SharedConstants.DockSpawn.Y + SharedConstants.OutOfBoundsYLimit) * .5f + yOffset, SharedConstants.DockSpawn.Z, 4250f, Math.Abs(SharedConstants.OutOfBoundsYLimit - SharedConstants.DockSpawn.Y) + Math.Abs(yOffset) * .5f);
@@ -25,7 +26,7 @@ namespace SurviveTheHuntClient.Helpers
             SetBlipColour(PlayAreaBlip.Value, (int)colour);
         }
 
-        internal static void Tick()
+        public void Tick(float deltaTime)
         {
             bool approachingBounds = CheckIsApproachingBounds();
             if (approachingBounds != WasApproachingBoundsLastTick && PlayAreaBlip.HasValue)

--- a/src/SurviveTheHuntClient/Helpers/KillTracker.cs
+++ b/src/SurviveTheHuntClient/Helpers/KillTracker.cs
@@ -1,28 +1,29 @@
 ﻿using CitizenFX.Core;
 using CitizenFX.Core.Native;
+using SurviveTheHuntClient.Interfaces;
 using SurviveTheHuntShared;
 using static CitizenFX.Core.Native.API;
 
 namespace SurviveTheHuntClient.Helpers
 {
-    internal static class KillTracker
+    internal class KillTracker : ITickable
     {
         public const float AttackerTimeout = 5f;
 
-        internal static float TimeSinceLastDamage = 0f;
+        internal float TimeSinceLastDamage = 0f;
 
-        internal static int? LastAttacker = null;
+        internal int? LastAttacker = null;
 
-        internal static int LastTickHealth = 0;
+        internal int LastTickHealth = 0;
 
-        internal static void Reset()
+        internal void Reset()
         {
             LastAttacker = null;
             LastTickHealth = 0;
             TimeSinceLastDamage = 0f;
         }
 
-        internal static void Tick()
+        public void Tick(float deltaTime)
         {
             int playerPed = PlayerPedId();
 
@@ -62,7 +63,7 @@ namespace SurviveTheHuntClient.Helpers
             }
         }
 
-        internal static KillFeedClientPayload GetKillInfo()
+        internal KillFeedClientPayload GetKillInfo()
         {
             if(TimeSinceLastDamage < AttackerTimeout && LastAttacker.HasValue)
             {

--- a/src/SurviveTheHuntClient/Helpers/PlayerPassenger.cs
+++ b/src/SurviveTheHuntClient/Helpers/PlayerPassenger.cs
@@ -1,4 +1,5 @@
 ﻿using CitizenFX.Core;
+using SurviveTheHuntClient.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,15 +9,15 @@ using static CitizenFX.Core.Native.API;
 
 namespace SurviveTheHuntClient.Helpers
 {
-    internal static class PlayerPassenger
+    internal class PlayerPassenger : ITickable
     {
-        private static float SecondsEnterControlHeld = 0f;
+        private float SecondsEnterControlHeld = 0f;
         private const float PassengerEntryActivationSeconds = 0.25f;
         private const int PassengerEntryActivationFrames = 10;
 
-        private static int FramesEnterControlHeld = 0;
-        private static bool IsGettingInAsPassenger = false;
-        private static int VehicleToEnterAsPassenger = 0;
+        private int FramesEnterControlHeld = 0;
+        private bool IsGettingInAsPassenger = false;
+        private int VehicleToEnterAsPassenger = 0;
 
         private static readonly int[] Buses =
         {
@@ -25,7 +26,7 @@ namespace SurviveTheHuntClient.Helpers
             GetHashKey("coach")
         };
 
-        internal static void Tick()
+        public void Tick(float deltaTime)
         {
             if(IsGettingInAsPassenger)
             {

--- a/src/SurviveTheHuntClient/Helpers/VehicleWeaponsTracker.cs
+++ b/src/SurviveTheHuntClient/Helpers/VehicleWeaponsTracker.cs
@@ -1,4 +1,5 @@
 ﻿using CitizenFX.Core;
+using SurviveTheHuntClient.Interfaces;
 using static CitizenFX.Core.Native.API;
 
 namespace SurviveTheHuntClient.Helpers
@@ -6,19 +7,26 @@ namespace SurviveTheHuntClient.Helpers
     /// <summary>
     /// Helper for disabling weaponised vehicles' guns
     /// </summary>
-    internal static class VehicleWeaponsTracker
+    internal class VehicleWeaponsTracker : ITickable
     {
-        internal static void Tick()
+        public void Tick(float deltaTime)
         {
-            Vehicle veh = Game.PlayerPed.CurrentVehicle;
-            if(veh?.Exists() == true && DoesVehicleHaveWeapons(veh.Handle))
+            foreach (Player player in PlayerList.Players)
             {
-                uint weapon = uint.MaxValue;
-
-                // If the player ped has a vehicle weapon equipped, disable it
-                if(GetCurrentPedVehicleWeapon(Game.PlayerPed.Handle, ref weapon))
+                if (player.IsAlive && player.Character.Exists())
                 {
-                    DisableVehicleWeapon(true, weapon, veh.Handle, Game.PlayerPed.Handle);
+                    Ped ped = player.Character;
+                    Vehicle veh = ped.CurrentVehicle;
+                    if (veh?.Exists() == true && DoesVehicleHaveWeapons(veh.Handle))
+                    {
+                        uint weapon = uint.MaxValue;
+
+                        // If the player ped has a vehicle weapon equipped, disable it
+                        if (GetCurrentPedVehicleWeapon(ped.Handle, ref weapon))
+                        {
+                            DisableVehicleWeapon(true, weapon, veh.Handle, ped.Handle);
+                        }
+                    }
                 }
             }
         }

--- a/src/SurviveTheHuntClient/Helpers/WastedAnim.cs
+++ b/src/SurviveTheHuntClient/Helpers/WastedAnim.cs
@@ -1,23 +1,24 @@
 ﻿using CitizenFX.Core;
+using SurviveTheHuntClient.Interfaces;
 using static CitizenFX.Core.Native.API;
 
 namespace SurviveTheHuntClient.Helpers
 {
-    internal static class WastedAnim
+    internal class WastedAnim : ITickable
     {
-        private static bool NeedsToPlayWastedScaleform = false;
+        private bool NeedsToPlayWastedScaleform = false;
         private const string GfxName = "generic";
         private const string ScaleformName = "MP_BIG_MESSAGE_FREEMODE";
         private const string MethodName = "SHOW_SHARD_WASTED_MP_MESSAGE";
 
-        private static int? ScaleformHandle = null;
-        private static bool ShouldShow = false;
+        private int? ScaleformHandle = null;
+        private bool ShouldShow = false;
 
         private const float SecondsTillShard = 0.4f;
-        private static float SecondsPassedSinceDeath = 0f;
-        private static int? CurrentSoundId = null;
+        private float SecondsPassedSinceDeath = 0f;
+        private int? CurrentSoundId = null;
 
-        internal static void NotifyDeath()
+        internal void NotifyDeath()
         {
             NeedsToPlayWastedScaleform = true;
             ShouldShow = true;
@@ -35,13 +36,13 @@ namespace SurviveTheHuntClient.Helpers
             PlaySoundFrontend(CurrentSoundId.Value, "MP_Flash", "WastedSounds", true);
         }
 
-        internal static void StopShowing()
+        internal void StopShowing()
         {
             ShouldShow = false;
             NeedsToPlayWastedScaleform = false;
         }
 
-        internal static void Tick()
+        public void Tick(float deltaTime)
         {
             if(NeedsToPlayWastedScaleform && ScaleformHandle.HasValue && HasScaleformMovieLoaded(ScaleformHandle.Value))
             {

--- a/src/SurviveTheHuntClient/Interfaces/ITickable.cs
+++ b/src/SurviveTheHuntClient/Interfaces/ITickable.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SurviveTheHuntClient.Interfaces
+{
+    internal interface ITickable
+    {
+        void Tick(float deltaTime);
+    }
+}

--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -17,6 +17,7 @@ using SharedConstants = SurviveTheHuntShared.Constants;
 using SurviveTheHuntShared.Core;
 using SurviveTheHuntShared;
 using System.Xml;
+using SurviveTheHuntClient.Interfaces;
 
 namespace SurviveTheHuntClient
 {
@@ -91,6 +92,13 @@ namespace SurviveTheHuntClient
         private uint? HunterGroupHash = null;
         private uint? HuntedGroupHash = null;
 
+        private readonly KillTracker KillTracker;
+        private readonly BoundsTracker BoundsTracker;
+        private readonly WastedAnim WastedAnim;
+        private readonly PlayerPassenger PlayerPassenger = new PlayerPassenger();
+
+        private readonly ITickable[] Tickables;
+
         public MainScript()
         {
             EventHandlers["onClientGameTypeStart"] += new Action<string>(OnClientGameTypeStart);
@@ -104,6 +112,17 @@ namespace SurviveTheHuntClient
             }
 
             DeathBlips = new DeathBlips(GetConvarInt("sth_deathbliplifespan", SharedConstants.DefaultDeathBlipLifespan));
+
+            KillTracker = new KillTracker();
+            BoundsTracker = new BoundsTracker();
+            WastedAnim = new WastedAnim();
+            Tickables = new ITickable[]
+            {
+                KillTracker,
+                BoundsTracker,
+                WastedAnim,
+                new VehicleWeaponsTracker()
+            };
         }
 
         protected void OnResourceStopping(string resourceName)
@@ -488,6 +507,8 @@ namespace SurviveTheHuntClient
 
         protected async Task UpdateLoop()
         {
+            float deltaTime = Game.LastFrameTime;
+
             if (Game.PlayerPed != null)
             {
                 ResetPlayerStamina(PlayerId());
@@ -517,7 +538,7 @@ namespace SurviveTheHuntClient
             HuntUI.UpdateTeammateBlips(Players, ref GameState, ref PlayerState);
 
             // PlayerPassenger needs to tick before the weapons are updated because we need to check if the hunted player can driveby.
-            PlayerPassenger.Tick();
+            PlayerPassenger.Tick(deltaTime);
             PlayerState.UpdateWeapons(Game.PlayerPed);
 
             // Check and report player death to the server if needed.
@@ -611,10 +632,10 @@ namespace SurviveTheHuntClient
 
             UpdateRelationships();
 
-            KillTracker.Tick();
-            BoundsTracker.Tick();
-            WastedAnim.Tick();
-            VehicleWeaponsTracker.Tick();
+            foreach(ITickable tickable in Tickables)
+            {
+                tickable.Tick(deltaTime);
+            }
 
             PlayerState.HandleTeleportToSpawn();
 

--- a/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
+++ b/src/SurviveTheHuntClient/SurviveTheHuntClient.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Helpers\WeaponAttachments.cs" />
     <Compile Include="HuntUI.cs" />
     <Compile Include="Integrations\LbgCharNeo.cs" />
+    <Compile Include="Interfaces\ITickable.cs" />
     <Compile Include="MainScript.cs" />
     <Compile Include="PlayerState.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
This PR fixes an issue where weaponised vehicles would appear as firing on other clients, despite it not appearing as firing to the player operating the vehicle. This was purely a visual issue but it should be fixed to avoid confusion.

Also refactored classes that tick every frame to implement "Tickable" interfaces, to simplify code splitting into systems etc.

Closes #111