### PR TITLE
fix(client): removed PRFs that caused incorrect poses on bikes

### DIFF
--- a/src/SurviveTheHuntClient/MainScript.cs
+++ b/src/SurviveTheHuntClient/MainScript.cs
@@ -661,10 +661,6 @@ namespace SurviveTheHuntClient
             // https://vhub.wiki/enums/PED_RESET_FLAGS
             // According to the wiki this should make the local player enter/exit vehicle faster like in GTAO
             SetPedResetFlag(playerPed, 237, true);
-            // This should prevent the ped from going into still pose... not sure what that means tho but I guess also desirable?
-            SetPedResetFlag(playerPed, 236, true);
-            // Prevent going into shunt
-            SetPedResetFlag(playerPed, 287, true);
             // Allow ped variations in vehicles
             SetPedResetFlag(playerPed, 326, true);
             // Reduce vehicle ram control loss (not sure if this actually applies to other players)


### PR DESCRIPTION
This PR removes PRFs that weren't needed and only caused player ped poses in vehicles to be incorrect

Closes #113

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/8f26d2f2-7699-4d62-95b4-d5d89989e144" />
